### PR TITLE
Backend/feature/error-codes, Adding error codes into swagger

### DIFF
--- a/prediction-polls/backend/src/errorCodes.js
+++ b/prediction-polls/backend/src/errorCodes.js
@@ -52,12 +52,12 @@ const errorCodes = {
 
   BAD_DISCRETE_POLL_REQUEST_ERROR: {
     code: 4000,
-    message: 'Request body for creating a discrete poll was bad.'
+    message: 'Bad request body for creating a discrete poll.'
   },
   
   BAD_CONT_POLL_REQUEST_ERROR: {
     code: 4001,
-    message: 'Request body for creating a continuous poll was bad.'
+    message: 'Bad request body for creating a continuous poll.'
   },
 
   MINMAX_BAD_CONT_POLL_REQUEST_ERROR: {

--- a/prediction-polls/backend/src/routes/PollRouter.js
+++ b/prediction-polls/backend/src/routes/PollRouter.js
@@ -27,6 +27,22 @@ const router = express.Router();
  *                   question:
  *                     type: string
  *                     example: "Who will become POTUS?"
+ *       500:
+ *         description: Internal Server Error
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 message:
+ *                   type: string
+ *                 code:
+ *                   type: integer
+ *             examples:
+ *               databaseError:
+ *                 value:
+ *                   message: Error while accessing the database.
+ *                   code: 3000
  */
 router.get('/discrete', service.getDiscretePolls);
 
@@ -122,9 +138,57 @@ router.get('/discrete/:pollId', authenticator.authorizeAccessToken, service.getD
  *       201:
  *         description: true
  *       400:
- *         description: Bad request
+ *         description: Bad Request
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 message:
+ *                   type: string
+ *                 code:
+ *                   type: integer
+ *             examples:
+ *               badRequest:
+ *                 value:
+ *                   message: Bad request body for creating a discrete poll.
+ *                   code: 4000
+ *               accessTokenNull:
+ *                 value:
+ *                   message: The access token is null
+ *                   code: 1005
+ *       401:
+ *         description: Unauthorized
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 message:
+ *                   type: string
+ *                 code:
+ *                   type: integer
+ *             examples:
+ *               accessTokenInvalid:
+ *                 value:
+ *                   message: The access token is invalid.
+ *                   code: 1001
  *       500:
  *         description: Internal Server Error
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 message:
+ *                   type: string
+ *                 code:
+ *                   type: integer
+ *             examples:
+ *               databaseError:
+ *                 value:
+ *                   message: Error while accessing the database.
+ *                   code: 3000
  */
 router.post('/discrete', authenticator.authorizeAccessToken, service.addDiscretePoll);
 
@@ -244,9 +308,61 @@ router.get('/continuous/:pollId', authenticator.authorizeAccessToken, service.ge
  *       201:
  *         description: true
  *       400:
- *         description: Bad request
+ *         description: Bad Request
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 message:
+ *                   type: string
+ *                 code:
+ *                   type: integer
+ *             examples:
+ *               badRequest:
+ *                 value:
+ *                   message: Bad request body for creating a continuous poll.
+ *                   code: 4001
+ *               MINMAX_BAD_CONT_POLL_REQUEST_ERROR:
+ *                 value:
+ *                   message: Minimum value allowed was higher than maximum value allowed in the poll.
+ *                   code: 4002
+ *               accessTokenNull:
+ *                 value:
+ *                   message: The access token is null
+ *                   code: 1005
+ *       401:
+ *         description: Unauthorized
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 message:
+ *                   type: string
+ *                 code:
+ *                   type: integer
+ *             examples:
+ *               accessTokenInvalid:
+ *                 value:
+ *                   message: The access token is invalid.
+ *                   code: 1001
  *       500:
  *         description: Internal Server Error
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 message:
+ *                   type: string
+ *                 code:
+ *                   type: integer
+ *             examples:
+ *               databaseError:
+ *                 value:
+ *                   message: Error while accessing the database.
+ *                   code: 3000
  */
 router.post('/continuous', authenticator.authorizeAccessToken, service.addContinuousPoll);
 


### PR DESCRIPTION
Error codes for post endpoints are done in swagger. Developers can look into the example responses and see the possible error codes that can come from a post endpoint.
<img width="880" alt="Screenshot 2023-11-19 at 20 12 31" src="https://github.com/bounswe/bounswe2023group4/assets/44020012/15abb2fe-51a3-4214-ba9c-e003253d21e7">
<img width="1217" alt="Screenshot 2023-11-19 at 20 12 57" src="https://github.com/bounswe/bounswe2023group4/assets/44020012/08b9a5c5-c78e-44f0-88d5-08370e42fedc">
We have both badRequest and accessTokenNull here in the 400 error response.