### PR TITLE
Adding creator name to poll objects

### DIFF
--- a/prediction-polls/backend/src/repositories/PollDB.js
+++ b/prediction-polls/backend/src/repositories/PollDB.js
@@ -59,16 +59,16 @@ async function getContinuousPollWithId(pollId){
     }
 }
 
-async function addDiscretePoll(question, choices, openVisibility, setDueDate, dueDatePoll, numericFieldValue, selectedTimeUnit){
+async function addDiscretePoll(question, username, choices, openVisibility, setDueDate, dueDatePoll, numericFieldValue, selectedTimeUnit){
     const connection = await pool.getConnection();
 
-    const sql_poll = 'INSERT INTO polls (question, poll_type, openVisibility, setDueDate, dueDatePoll, numericFieldValue, selectedTimeUnit) VALUES (?, ?, ?, ?, ?, ?, ?)';
+    const sql_poll = 'INSERT INTO polls (question, username, poll_type, openVisibility, setDueDate, dueDatePoll, numericFieldValue, selectedTimeUnit) VALUES (?, ?, ?, ?, ?, ?, ?, ?)';
     const sql_discrete_poll = 'INSERT INTO discrete_polls (id) VALUES (?)';
     const sql_choice = 'INSERT INTO discrete_poll_choices (choice_text, poll_id) VALUES (?, ?)';
 
     try {
         await connection.beginTransaction()
-        const [resultSetHeader] = await connection.query(sql_poll, [question, 'discrete', openVisibility, setDueDate, dueDatePoll, numericFieldValue, selectedTimeUnit]);
+        const [resultSetHeader] = await connection.query(sql_poll, [question, username, 'discrete', openVisibility, setDueDate, dueDatePoll, numericFieldValue, selectedTimeUnit]);
         poll_id = resultSetHeader.insertId;
 
         if (!poll_id) {
@@ -93,14 +93,14 @@ async function addDiscretePoll(question, choices, openVisibility, setDueDate, du
     }
 }
 
-async function addContinuousPoll(question, cont_poll_type, openVisibility, setDueDate, dueDatePoll, numericFieldValue, selectedTimeUnit){
+async function addContinuousPoll(question, username, cont_poll_type, openVisibility, setDueDate, dueDatePoll, numericFieldValue, selectedTimeUnit){
     const connection = await pool.getConnection();
 
-    const sql_poll = 'INSERT INTO polls (question, poll_type, openVisibility, setDueDate, dueDatePoll, numericFieldValue, selectedTimeUnit) VALUES (?, ?, ?, ?, ?, ?, ?)';
+    const sql_poll = 'INSERT INTO polls (question, username, poll_type, openVisibility, setDueDate, dueDatePoll, numericFieldValue, selectedTimeUnit) VALUES (?, ?, ?, ?, ?, ?, ?, ?)';
     const sql_continuous_poll = 'INSERT INTO continuous_polls (id, cont_poll_type) VALUES (?, ?)' 
 
     try {
-        const [resultSetHeader] = await connection.query(sql_poll, [question, 'continuous', openVisibility, setDueDate, dueDatePoll, numericFieldValue, selectedTimeUnit]);
+        const [resultSetHeader] = await connection.query(sql_poll, [question, username, 'continuous', openVisibility, setDueDate, dueDatePoll, numericFieldValue, selectedTimeUnit]);
         poll_id = resultSetHeader.insertId;
 
         if (!poll_id) {

--- a/prediction-polls/backend/src/routes/PollRouter.js
+++ b/prediction-polls/backend/src/routes/PollRouter.js
@@ -124,6 +124,16 @@ router.get('/', service.getPolls);
  *                   type: string
  *                 poll_type:
  *                   type: string
+ *                 openVisibility:
+ *                   type: integer
+ *                 setDueDate:
+ *                   type: integer
+ *                 dueDatePoll:
+ *                   type: string
+ *                 numericFieldValue:
+ *                   type: integer
+ *                 selectedTimeUnit:
+ *                   type: string
  *                 poll:
  *                   type: object
  *                   properties:
@@ -154,6 +164,11 @@ router.get('/', service.getPolls);
  *                   question: "Who will become POTUS?"
  *                   username: "user123"
  *                   poll_type: "discrete"
+ *                   openVisibility: 1 
+ *                   setDueDate: 1 
+ *                   dueDatePoll: "2023-11-20T21:00:00.000Z"
+ *                   numericFieldValue: 2 
+ *                   selectedTimeUnit: "min"
  *                   poll:
  *                     id: 1
  *                   choices:
@@ -171,6 +186,11 @@ router.get('/', service.getPolls);
  *                   question: "Test question?"
  *                   username: "GhostDragon"
  *                   poll_type: "continuous"
+ *                   openVisibility: 0 
+ *                   setDueDate: 0 
+ *                   dueDatePoll: null
+ *                   numericFieldValue: null
+ *                   selectedTimeUnit: null
  *                   poll:
  *                     id: 2
  *                   choices:

--- a/prediction-polls/backend/src/routes/PollRouter.js
+++ b/prediction-polls/backend/src/routes/PollRouter.js
@@ -26,20 +26,50 @@ const router = express.Router();
  *                     type: integer
  *                   question:
  *                     type: string
+ *                   username:
+ *                     type: string
  *                   poll_type:
+ *                     type: string
+ *                   openVisibility:
+ *                     type: integer
+ *                   setDueDate:
+ *                     type: integer
+ *                   dueDatePoll:
+ *                     type: string
+ *                   numericFieldValue:
+ *                     type: integer
+ *                   selectedTimeUnit:
  *                     type: string
  *             examples:
  *               genericExample:
  *                 value:
  *                   - id: 1
  *                     question: "Who will become POTUS?"
+ *                     username: "user1234"
  *                     poll_type: "discrete"
+ *                     openVisibility: 1 
+ *                     setDueDate: 1 
+ *                     dueDatePoll: "2023-11-20T21:00:00.000Z"
+ *                     numericFieldValue: 2 
+ *                     selectedTimeUnit: "min"
  *                   - id: 2
  *                     question: "Test3?"
+ *                     username: "GoodGambler"
  *                     poll_type: "continuous"
+ *                     openVisibility: 0 
+ *                     setDueDate: 0 
+ *                     dueDatePoll: null
+ *                     numericFieldValue: null
+ *                     selectedTimeUnit: null
  *                   - id: 3
  *                     question: "Who will become POTUS?"
+ *                     username: "GhostDragon"
  *                     poll_type: "discrete"
+ *                     openVisibility: 1 
+ *                     setDueDate: 1 
+ *                     dueDatePoll: "2023-11-20T21:00:00.000Z"
+ *                     numericFieldValue: 3
+ *                     selectedTimeUnit: "h"
  *       500:
  *         description: Internal Server Error
  *         content:
@@ -90,6 +120,8 @@ router.get('/', service.getPolls);
  *                   type: integer
  *                 question:
  *                   type: string
+ *                 username:
+ *                   type: string
  *                 poll_type:
  *                   type: string
  *                 poll:
@@ -120,6 +152,7 @@ router.get('/', service.getPolls);
  *                 value:
  *                   id: 1
  *                   question: "Who will become POTUS?"
+ *                   username: "user123"
  *                   poll_type: "discrete"
  *                   poll:
  *                     id: 1
@@ -136,11 +169,10 @@ router.get('/', service.getPolls);
  *                 value:
  *                   id: 2
  *                   question: "Test question?"
+ *                   username: "GhostDragon"
  *                   poll_type: "continuous"
  *                   poll:
  *                     id: 2
- *                     min_value: 6
- *                     max_value: 10
  *                   choices:
  *                     - 7
  *                     - 8   

--- a/prediction-polls/backend/src/schema.sql
+++ b/prediction-polls/backend/src/schema.sql
@@ -24,6 +24,7 @@ CREATE TABLE refresh_tokens (
 CREATE TABLE polls (
     id INT AUTO_INCREMENT PRIMARY KEY,
     question VARCHAR(255) NOT NULL,
+    username VARCHAR(255) NOT NULL,
     poll_type ENUM('discrete', 'continuous') NOT NULL,
     openVisibility BOOLEAN NOT NULL,
     setDueDate BOOLEAN NOT NULL,

--- a/prediction-polls/backend/src/services/PollService.js
+++ b/prediction-polls/backend/src/services/PollService.js
@@ -1,4 +1,5 @@
 const db = require("../repositories/PollDB.js");
+const { findUser } = require('../repositories/AuthorizationDB.js');
 const errorCodes = require("../errorCodes.js")
 
 function getPolls(req,res){
@@ -73,8 +74,9 @@ function addDiscretePoll(req,res){
     const numericFieldValue = req.body.numericFieldValue;
     const dueDatePoll = setDueDate ? new Date(req.body.dueDatePoll).toISOString().split('T')[0] : null;
     const selectedTimeUnit = req.body.selectedTimeUnit;
+    const username = req.user.name;
 
-    db.addDiscretePoll(question, choices, openVisibility, setDueDate, dueDatePoll, numericFieldValue, selectedTimeUnit)
+    db.addDiscretePoll(question, username, choices, openVisibility, setDueDate, dueDatePoll, numericFieldValue, selectedTimeUnit)
     .then((result) => {
         res.end(result.toString());
     })
@@ -138,8 +140,9 @@ function addContinuousPoll(req,res){
     const numericFieldValue = req.body.numericFieldValue;
     const dueDatePoll = setDueDate ? new Date(req.body.dueDatePoll).toISOString().split('T')[0] : null;
     const selectedTimeUnit = req.body.selectedTimeUnit;
+    const username = req.user.name;
 
-    db.addContinuousPoll(question, cont_poll_type, openVisibility, setDueDate, dueDatePoll, numericFieldValue, selectedTimeUnit)
+    db.addContinuousPoll(question, username, cont_poll_type, openVisibility, setDueDate, dueDatePoll, numericFieldValue, selectedTimeUnit)
     .then((result) => {
         res.end(result.toString());
     })


### PR DESCRIPTION
I added a "username" field to the objects we return from the /polls and /polls/{pollId} GET endpoints.
Currently: a GET /polls request returns something like this:
```
[
    {
        "id": 1,
        "question": "Question 4",
        "username": "sefik1",
        "poll_type": "discrete",
        "openVisibility": 1,
        "setDueDate": 1,
        "dueDatePoll": "2023-11-20T21:00:00.000Z",
        "numericFieldValue": 2,
        "selectedTimeUnit": "min"
    },
    {
        "id": 2,
        "question": "Test3?",
        "username": "sefik1",
        "poll_type": "continuous",
        "openVisibility": 1,
        "setDueDate": 1,
        "dueDatePoll": "2023-11-20T21:00:00.000Z",
        "numericFieldValue": 2,
        "selectedTimeUnit": "min"
    }
]
```
and a GET /polls/{pollId} for a discrete poll looks like this:
```
{
    "id": 1,
    "question": "Question 4",
    "username": "sefik1",
    "poll_type": "discrete",
    "openVisibility": 1,
    "setDueDate": 1,
    "dueDatePoll": "2023-11-20T21:00:00.000Z",
    "numericFieldValue": 2,
    "selectedTimeUnit": "min",
    "poll": {
        "id": 1
    },
    "choices": [
        {
            "id": 1,
            "choice_text": "choice 1",
            "poll_id": 1,
            "voter_count": 0
        },
        {
            "id": 2,
            "choice_text": "choice 2",
            "poll_id": 1,
            "voter_count": 0
        }
    ]
}
```
and a GET /polls/{pollId} for a continuous poll looks like this:
```
{
    "id": 2,
    "question": "Test3?",
    "username": "sefik1",
    "poll_type": "continuous",
    "openVisibility": 1,
    "setDueDate": 1,
    "dueDatePoll": "2023-11-20T21:00:00.000Z",
    "numericFieldValue": 2,
    "selectedTimeUnit": "min",
    "poll": {
        "id": 2,
        "cont_poll_type": "numeric"
    },
    "choices": []
}
```

IMPORTANT NOTE: When reviewing issue, you might see that the unnecessary "poll" property which is an object is still there, this is not in scope of this issue and will be addressed at https://github.com/bounswe/bounswe2023group4/issues/402
This issue is only concerned at adding the "username"property to the returned poll objects.


Also, I updated the swagger documentation.
You can check it by now by checking out the backend/feature/creatorName branch and running 
`npm install`
and
`npm run start`
and browsing `http://localhost:8000/api-docs`