### PR TITLE
/polls/{pollId} GET return object improvement

### DIFF
--- a/prediction-polls/backend/src/repositories/PollDB.js
+++ b/prediction-polls/backend/src/repositories/PollDB.js
@@ -59,16 +59,16 @@ async function getContinuousPollWithId(pollId){
     }
 }
 
-async function addDiscretePoll(question, choices, openVisibility, setDueDate, dueDatePoll, numericFieldValue, selectedTimeUnit){
+async function addDiscretePoll(question, username, choices, openVisibility, setDueDate, dueDatePoll, numericFieldValue, selectedTimeUnit){
     const connection = await pool.getConnection();
 
-    const sql_poll = 'INSERT INTO polls (question, poll_type, openVisibility, setDueDate, dueDatePoll, numericFieldValue, selectedTimeUnit) VALUES (?, ?, ?, ?, ?, ?, ?)';
+    const sql_poll = 'INSERT INTO polls (question, username, poll_type, openVisibility, setDueDate, dueDatePoll, numericFieldValue, selectedTimeUnit) VALUES (?, ?, ?, ?, ?, ?, ?, ?)';
     const sql_discrete_poll = 'INSERT INTO discrete_polls (id) VALUES (?)';
     const sql_choice = 'INSERT INTO discrete_poll_choices (choice_text, poll_id) VALUES (?, ?)';
 
     try {
         await connection.beginTransaction()
-        const [resultSetHeader] = await connection.query(sql_poll, [question, 'discrete', openVisibility, setDueDate, dueDatePoll, numericFieldValue, selectedTimeUnit]);
+        const [resultSetHeader] = await connection.query(sql_poll, [question, username, 'discrete', openVisibility, setDueDate, dueDatePoll, numericFieldValue, selectedTimeUnit]);
         poll_id = resultSetHeader.insertId;
 
         if (!poll_id) {
@@ -93,14 +93,14 @@ async function addDiscretePoll(question, choices, openVisibility, setDueDate, du
     }
 }
 
-async function addContinuousPoll(question, cont_poll_type, openVisibility, setDueDate, dueDatePoll, numericFieldValue, selectedTimeUnit){
+async function addContinuousPoll(question, username, cont_poll_type, openVisibility, setDueDate, dueDatePoll, numericFieldValue, selectedTimeUnit){
     const connection = await pool.getConnection();
 
-    const sql_poll = 'INSERT INTO polls (question, poll_type, openVisibility, setDueDate, dueDatePoll, numericFieldValue, selectedTimeUnit) VALUES (?, ?, ?, ?, ?, ?, ?)';
+    const sql_poll = 'INSERT INTO polls (question, username, poll_type, openVisibility, setDueDate, dueDatePoll, numericFieldValue, selectedTimeUnit) VALUES (?, ?, ?, ?, ?, ?, ?, ?)';
     const sql_continuous_poll = 'INSERT INTO continuous_polls (id, cont_poll_type) VALUES (?, ?)' 
 
     try {
-        const [resultSetHeader] = await connection.query(sql_poll, [question, 'continuous', openVisibility, setDueDate, dueDatePoll, numericFieldValue, selectedTimeUnit]);
+        const [resultSetHeader] = await connection.query(sql_poll, [question, username, 'continuous', openVisibility, setDueDate, dueDatePoll, numericFieldValue, selectedTimeUnit]);
         poll_id = resultSetHeader.insertId;
 
         if (!poll_id) {

--- a/prediction-polls/backend/src/repositories/PollDB.js
+++ b/prediction-polls/backend/src/repositories/PollDB.js
@@ -62,7 +62,7 @@ async function getContinuousPollWithId(pollId){
 async function addDiscretePoll(question, username, choices, openVisibility, setDueDate, dueDatePoll, numericFieldValue, selectedTimeUnit){
     const connection = await pool.getConnection();
 
-    const sql_poll = 'INSERT INTO polls (question, username, poll_type, openVisibility, setDueDate, dueDatePoll, numericFieldValue, selectedTimeUnit) VALUES (?, ?, ?, ?, ?, ?, ?, ?)';
+    const sql_poll = 'INSERT INTO polls (question, username, poll_type, openVisibility, setDueDate, closingDate, numericFieldValue, selectedTimeUnit) VALUES (?, ?, ?, ?, ?, ?, ?, ?)';
     const sql_discrete_poll = 'INSERT INTO discrete_polls (id) VALUES (?)';
     const sql_choice = 'INSERT INTO discrete_poll_choices (choice_text, poll_id) VALUES (?, ?)';
 
@@ -96,7 +96,7 @@ async function addDiscretePoll(question, username, choices, openVisibility, setD
 async function addContinuousPoll(question, username, cont_poll_type, openVisibility, setDueDate, dueDatePoll, numericFieldValue, selectedTimeUnit){
     const connection = await pool.getConnection();
 
-    const sql_poll = 'INSERT INTO polls (question, username, poll_type, openVisibility, setDueDate, dueDatePoll, numericFieldValue, selectedTimeUnit) VALUES (?, ?, ?, ?, ?, ?, ?, ?)';
+    const sql_poll = 'INSERT INTO polls (question, username, poll_type, openVisibility, setDueDate, closingDate, numericFieldValue, selectedTimeUnit) VALUES (?, ?, ?, ?, ?, ?, ?, ?)';
     const sql_continuous_poll = 'INSERT INTO continuous_polls (id, cont_poll_type) VALUES (?, ?)' 
 
     try {

--- a/prediction-polls/backend/src/routes/PollRouter.js
+++ b/prediction-polls/backend/src/routes/PollRouter.js
@@ -124,6 +124,16 @@ router.get('/', service.getPolls);
  *                   type: string
  *                 poll_type:
  *                   type: string
+ *                 openVisibility:
+ *                   type: integer
+ *                 setDueDate:
+ *                   type: integer
+ *                 dueDatePoll:
+ *                   type: string
+ *                 numericFieldValue:
+ *                   type: integer
+ *                 selectedTimeUnit:
+ *                   type: string
  *                 poll:
  *                   type: object
  *                   properties:
@@ -154,6 +164,11 @@ router.get('/', service.getPolls);
  *                   question: "Who will become POTUS?"
  *                   username: "user123"
  *                   poll_type: "discrete"
+ *                   openVisibility: 1 
+ *                   setDueDate: 1 
+ *                   dueDatePoll: "2023-11-20T21:00:00.000Z"
+ *                   numericFieldValue: 2 
+ *                   selectedTimeUnit: "min"
  *                   poll:
  *                     id: 1
  *                   choices:
@@ -171,6 +186,11 @@ router.get('/', service.getPolls);
  *                   question: "Test question?"
  *                   username: "GhostDragon"
  *                   poll_type: "continuous"
+ *                   openVisibility: 0 
+ *                   setDueDate: 0 
+ *                   dueDatePoll: null
+ *                   numericFieldValue: null
+ *                   selectedTimeUnit: null
  *                   poll:
  *                     id: 2
  *                   choices:

--- a/prediction-polls/backend/src/routes/PollRouter.js
+++ b/prediction-polls/backend/src/routes/PollRouter.js
@@ -120,25 +120,26 @@ router.get('/', service.getPolls);
  *                   type: integer
  *                 question:
  *                   type: string
- *                 username:
+ *                 tags:
+ *                   type: array
+ *                   items: 
+ *                     type: string
+ *                 creatorName:
  *                   type: string
- *                 poll_type:
+ *                 creatorUsername:
  *                   type: string
- *                 openVisibility:
- *                   type: integer
+ *                 creatorImage:
+ *                   type: string
+ *                 pollType:
+ *                   type: string
+ *                 closingDate:
+ *                   type: string
+ *                 rejectVotes:
+ *                   type: string
  *                 setDueDate:
  *                   type: integer
  *                 dueDatePoll:
  *                   type: string
- *                 numericFieldValue:
- *                   type: integer
- *                 selectedTimeUnit:
- *                   type: string
- *                 poll:
- *                   type: object
- *                   properties:
- *                     id:
- *                       type: integer
  *                 choices:
  *                   oneOf:
  *                     - type: array
@@ -162,15 +163,14 @@ router.get('/', service.getPolls);
  *                 value:
  *                   id: 1
  *                   question: "Who will become POTUS?"
- *                   username: "user123"
- *                   poll_type: "discrete"
- *                   openVisibility: 1 
+ *                   tags: ["tag1", "tag2"]
+ *                   creatorName: "user123"
+ *                   creatorUsername: "GhostDragon"
+ *                   creatorImage: null
+ *                   pollType: "discrete"
+ *                   rejectVotes: "5 min"
  *                   setDueDate: 1 
- *                   dueDatePoll: "2023-11-20T21:00:00.000Z"
- *                   numericFieldValue: 2 
- *                   selectedTimeUnit: "min"
- *                   poll:
- *                     id: 1
+ *                   closingDate: "2023-11-20T21:00:00.000Z"
  *                   choices:
  *                     - id: 1
  *                       choice_text: "Trumpo"
@@ -184,15 +184,14 @@ router.get('/', service.getPolls);
  *                 value:
  *                   id: 2
  *                   question: "Test question?"
- *                   username: "GhostDragon"
- *                   poll_type: "continuous"
- *                   openVisibility: 0 
+ *                   tags: ["tag1", "tag2"]
+ *                   creatorName: "GhostDragon"
+ *                   creatorUsername: "GhostDragon"
+ *                   creatorImage: null
+ *                   pollType: "continuous"
+ *                   rejectVotes: "2 hr"
  *                   setDueDate: 0 
- *                   dueDatePoll: null
- *                   numericFieldValue: null
- *                   selectedTimeUnit: null
- *                   poll:
- *                     id: 2
+ *                   closingDate: null
  *                   choices:
  *                     - 7
  *                     - 8   

--- a/prediction-polls/backend/src/routes/PollRouter.js
+++ b/prediction-polls/backend/src/routes/PollRouter.js
@@ -26,20 +26,50 @@ const router = express.Router();
  *                     type: integer
  *                   question:
  *                     type: string
+ *                   username:
+ *                     type: string
  *                   poll_type:
+ *                     type: string
+ *                   openVisibility:
+ *                     type: integer
+ *                   setDueDate:
+ *                     type: integer
+ *                   dueDatePoll:
+ *                     type: string
+ *                   numericFieldValue:
+ *                     type: integer
+ *                   selectedTimeUnit:
  *                     type: string
  *             examples:
  *               genericExample:
  *                 value:
  *                   - id: 1
  *                     question: "Who will become POTUS?"
+ *                     username: "user1234"
  *                     poll_type: "discrete"
+ *                     openVisibility: 1 
+ *                     setDueDate: 1 
+ *                     dueDatePoll: "2023-11-20T21:00:00.000Z"
+ *                     numericFieldValue: 2 
+ *                     selectedTimeUnit: "min"
  *                   - id: 2
  *                     question: "Test3?"
+ *                     username: "GoodGambler"
  *                     poll_type: "continuous"
+ *                     openVisibility: 0 
+ *                     setDueDate: 0 
+ *                     dueDatePoll: null
+ *                     numericFieldValue: null
+ *                     selectedTimeUnit: null
  *                   - id: 3
  *                     question: "Who will become POTUS?"
+ *                     username: "GhostDragon"
  *                     poll_type: "discrete"
+ *                     openVisibility: 1 
+ *                     setDueDate: 1 
+ *                     dueDatePoll: "2023-11-20T21:00:00.000Z"
+ *                     numericFieldValue: 3
+ *                     selectedTimeUnit: "h"
  *       500:
  *         description: Internal Server Error
  *         content:
@@ -90,6 +120,8 @@ router.get('/', service.getPolls);
  *                   type: integer
  *                 question:
  *                   type: string
+ *                 username:
+ *                   type: string
  *                 poll_type:
  *                   type: string
  *                 poll:
@@ -120,6 +152,7 @@ router.get('/', service.getPolls);
  *                 value:
  *                   id: 1
  *                   question: "Who will become POTUS?"
+ *                   username: "user123"
  *                   poll_type: "discrete"
  *                   poll:
  *                     id: 1
@@ -136,11 +169,10 @@ router.get('/', service.getPolls);
  *                 value:
  *                   id: 2
  *                   question: "Test question?"
+ *                   username: "GhostDragon"
  *                   poll_type: "continuous"
  *                   poll:
  *                     id: 2
- *                     min_value: 6
- *                     max_value: 10
  *                   choices:
  *                     - 7
  *                     - 8   

--- a/prediction-polls/backend/src/routes/PollRouter.js
+++ b/prediction-polls/backend/src/routes/PollRouter.js
@@ -132,14 +132,14 @@ router.get('/', service.getPolls);
  *                   type: string
  *                 pollType:
  *                   type: string
- *                 closingDate:
- *                   type: string
  *                 rejectVotes:
  *                   type: string
  *                 setDueDate:
  *                   type: integer
- *                 dueDatePoll:
+ *                 closingDate:
  *                   type: string
+ *                 isOpen:
+ *                   type: integer
  *                 choices:
  *                   oneOf:
  *                     - type: array
@@ -171,6 +171,7 @@ router.get('/', service.getPolls);
  *                   rejectVotes: "5 min"
  *                   setDueDate: 1 
  *                   closingDate: "2023-11-20T21:00:00.000Z"
+ *                   isOpen: 1 
  *                   choices:
  *                     - id: 1
  *                       choice_text: "Trumpo"
@@ -192,6 +193,8 @@ router.get('/', service.getPolls);
  *                   rejectVotes: "2 hr"
  *                   setDueDate: 0 
  *                   closingDate: null
+ *                   isOpen: 1 
+ *                   cont_poll_type: "numeric"
  *                   choices:
  *                     - 7
  *                     - 8   

--- a/prediction-polls/backend/src/schema.sql
+++ b/prediction-polls/backend/src/schema.sql
@@ -28,7 +28,7 @@ CREATE TABLE polls (
     poll_type ENUM('discrete', 'continuous') NOT NULL,
     openVisibility BOOLEAN NOT NULL,
     setDueDate BOOLEAN NOT NULL,
-    dueDatePoll DATE,
+    closingDate DATE,
     numericFieldValue INT,
     selectedTimeUnit ENUM('min', 'h', 'day', 'mth')
 );

--- a/prediction-polls/backend/src/schema.sql
+++ b/prediction-polls/backend/src/schema.sql
@@ -24,6 +24,7 @@ CREATE TABLE refresh_tokens (
 CREATE TABLE polls (
     id INT AUTO_INCREMENT PRIMARY KEY,
     question VARCHAR(255) NOT NULL,
+    username VARCHAR(255) NOT NULL,
     poll_type ENUM('discrete', 'continuous') NOT NULL,
     openVisibility BOOLEAN NOT NULL,
     setDueDate BOOLEAN NOT NULL,

--- a/prediction-polls/backend/src/services/PollService.js
+++ b/prediction-polls/backend/src/services/PollService.js
@@ -117,7 +117,7 @@ function getContinuousPollWithId(req,res, responseBody){
         } else {
             db.getContinuousPollVotes(pollId)
             .then((choices) => {
-                responseBody = {...responseBody, "options": choices}
+                responseBody = {...responseBody, "cont_poll_type": rows[0].cont_poll_type, "options": choices}
                 res.json(responseBody)
             })
         }

--- a/prediction-polls/backend/src/services/PollService.js
+++ b/prediction-polls/backend/src/services/PollService.js
@@ -52,7 +52,17 @@ function getPollWithId(req, res) {
                     })
                 })
             } else if (pollType === 'continuous') {
-                getContinuousPollWithId(req, res, properties);
+                db.getContinuousPollWithId(pollId)
+                .then((rows) => {
+                    if (rows.length === 0) {
+                        res.status(404).json({error: errorCodes.NO_SUCH_POLL_ERROR});
+                    } else {
+                        db.getContinuousPollVotes(pollId)
+                        .then((choices) => {
+                            res.json({...properties, "cont_poll_type": rows[0].cont_poll_type, "options": choices});
+                        })
+                    }
+                })
             }
         }
     })
@@ -100,27 +110,6 @@ function validateAddDiscretePoll(body) {
     }
     
     return true;
-}
-
-function getContinuousPollWithId(req,res, responseBody){
-    const pollId = req.params.pollId;
-
-    db.getContinuousPollWithId(pollId)
-    .then((rows) => {
-        if (rows.length === 0) {
-            res.status(404).json({error: errorCodes.NO_SUCH_POLL_ERROR});
-        } else {
-            db.getContinuousPollVotes(pollId)
-            .then((choices) => {
-                responseBody = {...responseBody, "cont_poll_type": rows[0].cont_poll_type, "options": choices}
-                res.json(responseBody)
-            })
-        }
-    })
-    .catch((error) => {
-        console.error(error);
-        res.status(500).json({error: errorCodes.DATABASE_ERROR});
-    })
 }
 
 function addContinuousPoll(req,res){

--- a/prediction-polls/backend/src/services/PollService.js
+++ b/prediction-polls/backend/src/services/PollService.js
@@ -1,4 +1,5 @@
 const db = require("../repositories/PollDB.js");
+const { findUser } = require('../repositories/AuthorizationDB.js');
 const errorCodes = require("../errorCodes.js")
 
 function getPolls(req,res){
@@ -73,8 +74,9 @@ function addDiscretePoll(req,res){
     const numericFieldValue = req.body.numericFieldValue;
     const dueDatePoll = setDueDate ? new Date(req.body.dueDatePoll).toISOString().split('T')[0] : null;
     const selectedTimeUnit = req.body.selectedTimeUnit;
+    const username = req.user.name;
 
-    db.addDiscretePoll(question, choices, openVisibility, setDueDate, dueDatePoll, numericFieldValue, selectedTimeUnit)
+    db.addDiscretePoll(question, username, choices, openVisibility, setDueDate, dueDatePoll, numericFieldValue, selectedTimeUnit)
     .then((result) => {
         res.end(result.toString());
     })
@@ -138,8 +140,9 @@ function addContinuousPoll(req,res){
     const numericFieldValue = req.body.numericFieldValue;
     const dueDatePoll = setDueDate ? new Date(req.body.dueDatePoll).toISOString().split('T')[0] : null;
     const selectedTimeUnit = req.body.selectedTimeUnit;
+    const username = req.user.name;
 
-    db.addContinuousPoll(question, cont_poll_type, openVisibility, setDueDate, dueDatePoll, numericFieldValue, selectedTimeUnit)
+    db.addContinuousPoll(question, username, cont_poll_type, openVisibility, setDueDate, dueDatePoll, numericFieldValue, selectedTimeUnit)
     .then((result) => {
         res.end(result.toString());
     })

--- a/prediction-polls/backend/src/services/PollService.js
+++ b/prediction-polls/backend/src/services/PollService.js
@@ -20,12 +20,25 @@ function getPollWithId(req, res) {
         if (rows.length === 0) {
             res.status(404).json({error: errorCodes.NO_SUCH_POLL_ERROR});
         } else {
-            const pollType = rows[0].poll_type;
-            const responseBody = rows[0];
+            const pollObject = rows[0];
+            const pollType = pollObject.poll_type;
+            const properties = {
+                "id": pollObject.id,
+                "question": pollObject.question,
+                "tags": [],
+                "creatorName": pollObject.username,
+                "creatorUsername": pollObject.username,
+                "creatorImage": null,
+                "pollType": pollObject.poll_type,
+                "rejectVotes": `${pollObject.numericFieldValue} ${pollObject.selectedTimeUnit}`,
+                "isOpen": true,
+                "comments": []
+            }
+
             if (pollType === 'discrete') {
-                getDiscretePollWithId(req, res, responseBody);
+                getDiscretePollWithId(req, res, properties);
             } else if (pollType === 'continuous') {
-                getContinuousPollWithId(req, res, responseBody);
+                getContinuousPollWithId(req, res, properties);
             }
         }
     })

--- a/prediction-polls/backend/src/services/PollService.js
+++ b/prediction-polls/backend/src/services/PollService.js
@@ -51,7 +51,7 @@ function getDiscretePollWithId(req,res, responseBody){
 
                 Promise.all(choicesWithVoteCount)
                 .then((updatedChoices) => {
-                    responseBody = { ...responseBody, "poll": rows[0], "options": updatedChoices };
+                    responseBody = { ...responseBody, "options": updatedChoices };
                     res.json(responseBody);
                 })
             })
@@ -117,7 +117,7 @@ function getContinuousPollWithId(req,res, responseBody){
         } else {
             db.getContinuousPollVotes(pollId)
             .then((choices) => {
-                responseBody = {...responseBody, "poll": rows[0], "options": choices}
+                responseBody = {...responseBody, "options": choices}
                 res.json(responseBody)
             })
         }

--- a/prediction-polls/backend/src/services/PollService.js
+++ b/prediction-polls/backend/src/services/PollService.js
@@ -30,6 +30,7 @@ function getPollWithId(req, res) {
                 "creatorUsername": pollObject.username,
                 "creatorImage": null,
                 "pollType": pollObject.poll_type,
+                "closingDate": pollObject.closingDate,
                 "rejectVotes": `${pollObject.numericFieldValue} ${pollObject.selectedTimeUnit}`,
                 "isOpen": true,
                 "comments": []

--- a/prediction-polls/backend/src/services/PollService.js
+++ b/prediction-polls/backend/src/services/PollService.js
@@ -51,7 +51,7 @@ function getDiscretePollWithId(req,res, responseBody){
 
                 Promise.all(choicesWithVoteCount)
                 .then((updatedChoices) => {
-                    responseBody = { ...responseBody, "poll": rows[0], "choices": updatedChoices };
+                    responseBody = { ...responseBody, "poll": rows[0], "options": updatedChoices };
                     res.json(responseBody);
                 })
             })
@@ -117,7 +117,7 @@ function getContinuousPollWithId(req,res, responseBody){
         } else {
             db.getContinuousPollVotes(pollId)
             .then((choices) => {
-                responseBody = {...responseBody, "poll": rows[0], "choices": choices}
+                responseBody = {...responseBody, "poll": rows[0], "options": choices}
                 res.json(responseBody)
             })
         }


### PR DESCRIPTION
- Add username as "creatorName" to poll table.
- change "choices" in the returned poll object to "options"
- remove unnecessary "poll" property when returning poll objects.
- add "cont_poll_type" to continuous polls. This can be "numeric" or "date". This corresponds to continuous polls with integer answers or date answers.
- change dueDatePoll name to closingDate
- Add additional properties requested in https://github.com/bounswe/bounswe2023group4/issues/428
  - "tags" return an empty array for now
  - "creatorName" and "creatorUsername" returns the same string for now.
  - "creatorImage" returns null. You can use a default picture for this for now. 
  - "isCustomPoll" is not returned. instead see "pollType" property. "pollType" can only be "discrete" and "continuous" for discrete and continuous polls respectively.
  - for discrete polls "options" have:
    - "choice_text" for the text of the choice.
    - "id" for the choice's id.
    - "voter_count" for the number of people voted for this option.
  - "rejectVotes" has the time before votes will start getting rejected.
  - "comments" returns an empty array as it is not yet implemented for now.