### PR TITLE
Fix rejectVotes null issue

### DIFF
--- a/prediction-polls/backend/src/services/PollService.js
+++ b/prediction-polls/backend/src/services/PollService.js
@@ -18,7 +18,7 @@ async function getPolls(req,res){
                 "creatorImage": null,
                 "pollType": pollObject.poll_type,
                 "closingDate": pollObject.closingDate,
-                "rejectVotes": `${pollObject.numericFieldValue} ${pollObject.selectedTimeUnit}`,
+                "rejectVotes": (pollObject.numericFieldValue && pollObject.selectedTimeUnit) ? `${pollObject.numericFieldValue} ${pollObject.selectedTimeUnit}` : null,
                 "isOpen": true,
                 "comments": []
             };
@@ -70,7 +70,7 @@ async function getPollWithId(req, res) {
             "creatorImage": null,
             "pollType": pollObject.poll_type,
             "closingDate": pollObject.closingDate,
-            "rejectVotes": `${pollObject.numericFieldValue} ${pollObject.selectedTimeUnit}`,
+            "rejectVotes": (pollObject.numericFieldValue && pollObject.selectedTimeUnit) ? `${pollObject.numericFieldValue} ${pollObject.selectedTimeUnit}` : null,
             "isOpen": true,
             "comments": []
         };


### PR DESCRIPTION
refer to #450.
This PR now checks if the selectedTimeUnit and numericFieldValue is null in the database.
If they are null, we return null as rejectedVotes.
If they are both not null, there is no change.