### PR TITLE
Implement /polls/close endpoint

### DIFF
--- a/prediction-polls/backend/src/repositories/PollDB.js
+++ b/prediction-polls/backend/src/repositories/PollDB.js
@@ -161,6 +161,12 @@ async function voteDiscretePoll(pollId, userId, choiceId, pointsSpent){
     try {
         await connection.beginTransaction()
 
+        const pollObject = await getPollWithId(pollId);
+
+        if (pollObject[0].isOpen == 0) {
+            throw { error: errorCodes.DATABASE_ERROR };
+        }
+
         const [rows] = await connection.query(findPointsSql, [userId]);
         const current_points = rows[0].points;
 
@@ -203,6 +209,12 @@ async function voteContinuousPoll(pollId, userId, choice, contPollType, pointsSp
 
     try {
         await connection.beginTransaction()
+
+        const pollObject = await getPollWithId(pollId);
+
+        if (pollObject[0].isOpen == 0) {
+            throw { error: errorCodes.DATABASE_ERROR };
+        }
 
         const [rows] = await connection.query(findPointsSql, [userId]);
         const current_points = rows[0].points;

--- a/prediction-polls/backend/src/routes/PollRouter.js
+++ b/prediction-polls/backend/src/routes/PollRouter.js
@@ -545,5 +545,7 @@ router.post('/discrete/:pollId/vote',authenticator.authorizeAccessToken, service
  */
 router.post('/continuous/:pollId/vote',authenticator.authorizeAccessToken, service.voteContinuousPoll);
 
+router.post('/close/:pollId', authenticator.authorizeAccessToken, service.closePoll);
+
 module.exports = router;
 

--- a/prediction-polls/backend/src/routes/PollRouter.js
+++ b/prediction-polls/backend/src/routes/PollRouter.js
@@ -545,6 +545,41 @@ router.post('/discrete/:pollId/vote',authenticator.authorizeAccessToken, service
  */
 router.post('/continuous/:pollId/vote',authenticator.authorizeAccessToken, service.voteContinuousPoll);
 
+/**
+ * @swagger
+ * /polls/close/{pollId}:
+ *   post:
+ *     tags:
+ *       - polls
+ *     description: Close a discrete poll and redistribute its points
+ *     parameters:
+ *       - in: path
+ *         name: pollId
+ *         required: true
+ *         schema:
+ *           type: integer
+ *         description: The ID of the continuous poll to vote on.
+ *     requestBody:
+ *       description: Vote details
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               choiceId:
+ *                 type: integer
+ *                 example: 1 
+ *     responses:
+ *       200:
+ *         description: Poll closed successfully
+ *       400:
+ *         description: Bad request
+ *       404:
+ *         description: Poll not found
+ *       500:
+ *         description: Internal Server Error
+ */
 router.post('/close/:pollId', authenticator.authorizeAccessToken, service.closePoll);
 
 module.exports = router;

--- a/prediction-polls/backend/src/schema.sql
+++ b/prediction-polls/backend/src/schema.sql
@@ -30,7 +30,8 @@ CREATE TABLE polls (
     setDueDate BOOLEAN NOT NULL,
     closingDate DATE,
     numericFieldValue INT,
-    selectedTimeUnit ENUM('min', 'h', 'day', 'mth')
+    selectedTimeUnit ENUM('min', 'h', 'day', 'mth'),
+    isOpen BOOLEAN DEFAULT true
 );
 
 CREATE TABLE discrete_polls (

--- a/prediction-polls/backend/src/services/PollService.js
+++ b/prediction-polls/backend/src/services/PollService.js
@@ -293,21 +293,13 @@ async function closePoll(req, res) {
         }
 
         const selections = await db.getDiscreteSelectionsWithPollId(pollId);
-        console.log("selections: ", selections);
-
         const totalPointsBet = selections.reduce((sum, selection) => sum + selection.given_points, 0);
-        console.log("totalPointsBet: ", totalPointsBet);
-
         const correctSelections = selections.filter(selection => selection.choice_id === choiceId);
-        console.log("correctSelections: ", correctSelections);
-
         const totalCorrectBet = correctSelections.reduce((sum, selection) => sum + selection.given_points, 0);
-        console.log("totalCorrectBet: ", totalCorrectBet);
 
         const rewardPoints = correctSelections.map((selection) => {
             return {user_id: selection.user_id, reward: Math.floor(totalPointsBet * (selection.given_points / totalCorrectBet))}
         })
-        console.log("rewardPoints: ", rewardPoints);
 
         await db.closePoll(pollId, rewardPoints);
 

--- a/prediction-polls/backend/src/services/PollService.js
+++ b/prediction-polls/backend/src/services/PollService.js
@@ -19,7 +19,7 @@ async function getPolls(req,res){
                 "pollType": pollObject.poll_type,
                 "closingDate": pollObject.closingDate,
                 "rejectVotes": (pollObject.numericFieldValue && pollObject.selectedTimeUnit) ? `${pollObject.numericFieldValue} ${pollObject.selectedTimeUnit}` : null,
-                "isOpen": true,
+                "isOpen": pollObject.isOpen ? true : false,
                 "comments": []
             };
 
@@ -71,7 +71,7 @@ async function getPollWithId(req, res) {
             "pollType": pollObject.poll_type,
             "closingDate": pollObject.closingDate,
             "rejectVotes": (pollObject.numericFieldValue && pollObject.selectedTimeUnit) ? `${pollObject.numericFieldValue} ${pollObject.selectedTimeUnit}` : null,
-            "isOpen": true,
+            "isOpen": pollObject.isOpen ? true : false,
             "comments": []
         };
     
@@ -261,4 +261,64 @@ async function voteContinuousPoll(req, res) {
     }
 }
 
-module.exports = {getPolls, getPollWithId, addDiscretePoll, addContinuousPoll, voteDiscretePoll, voteContinuousPoll}
+async function closePoll(req, res) {
+    try {
+        const pollIdInput = req.params.pollId;
+        const choiceIdInput = req.body.choiceId;
+
+        if (!(/^\d+$/.test(pollIdInput))) {
+            throw {error: {code: 5100, message: "pollId not a number."}};
+        }
+
+        if (!(typeof choiceIdInput === 'number')) {
+            throw {error: {code: 5101, message: "choiceId not a number."}}
+        }
+
+        pollId = parseInt(pollIdInput);
+        choiceId = parseInt(choiceIdInput);
+
+        const rows = await db.getPollWithId(pollId);
+        if (rows.length === 0) {
+            throw errorCodes.NO_SUCH_POLL_ERROR;
+        }
+
+        const pollObject = rows[0];
+
+        if (pollObject.poll_type === 'continuous') {
+            throw {error: {code: 5102, message: "Closing unsupported."}};
+        }
+
+        if (!pollObject.isOpen) {
+            throw {error: {code: 5013, message: "Poll already closed"}};
+        }
+
+        const selections = await db.getDiscreteSelectionsWithPollId(pollId);
+        console.log("selections: ", selections);
+
+        const totalPointsBet = selections.reduce((sum, selection) => sum + selection.given_points, 0);
+        console.log("totalPointsBet: ", totalPointsBet);
+
+        const correctSelections = selections.filter(selection => selection.choice_id === choiceId);
+        console.log("correctSelections: ", correctSelections);
+
+        const totalCorrectBet = correctSelections.reduce((sum, selection) => sum + selection.given_points, 0);
+        console.log("totalCorrectBet: ", totalCorrectBet);
+
+        const rewardPoints = correctSelections.map((selection) => {
+            return {user_id: selection.user_id, reward: Math.floor(totalPointsBet * (selection.given_points / totalCorrectBet))}
+        })
+        console.log("rewardPoints: ", rewardPoints);
+
+        await db.closePoll(pollId, rewardPoints);
+
+        res.status(200).json({success: true});
+    } catch (error) {
+        if (error) {
+            res.status(400).json(error);
+        } else {
+            res.status(500).json({ error: errorCodes.DATABASE_ERROR });
+        }
+    }
+}
+
+module.exports = {getPolls, getPollWithId, addDiscretePoll, addContinuousPoll, voteDiscretePoll, voteContinuousPoll, closePoll}


### PR DESCRIPTION
This PR implements /poll/close endpoint for future poll closing needs. This only works for discrete polls (multiple choice polls) for now.

Endpoint requires a choiceId to be sent through the request body. This is the correct choice.

- We collect all the selections for the concerned poll.
- We calculate the total points spent on this poll.
- We calculate the total points of correct guessers on this poll.
- Every correct guesser gains back their points invested with the formula ((individual point / total correct points) * total points).
- From now on the corresponding poll object has property `isOpen: false`
