### PR TITLE
Fix Username Email bug

### DIFF
--- a/prediction-polls/backend/src/services/PollService.js
+++ b/prediction-polls/backend/src/services/PollService.js
@@ -115,7 +115,8 @@ async function addDiscretePoll(req, res) {
         const numericFieldValue = req.body.numericFieldValue;
         const dueDatePoll = setDueDate ? new Date(req.body.dueDatePoll).toISOString().split('T')[0] : null;
         const selectedTimeUnit = req.body.selectedTimeUnit;
-        const username = req.user.name;
+        const findUserResult = await findUser({userId: req.user.id});
+        const username = findUserResult.username;
 
         const result = await db.addDiscretePoll(
             question,
@@ -172,7 +173,8 @@ async function addContinuousPoll(req, res) {
         const numericFieldValue = req.body.numericFieldValue;
         const dueDatePoll = setDueDate ? new Date(req.body.dueDatePoll).toISOString().split('T')[0] : null;
         const selectedTimeUnit = req.body.selectedTimeUnit;
-        const username = req.user.name;
+        const findUserResult = await findUser({userId: req.user.id});
+        const username = findUserResult.username;
 
         const result = await db.addContinuousPoll(
             question,


### PR DESCRIPTION
Poll objects contain their creator's username. But this was pulled from the jwt accessToken. As a consequence, if the user logs in with email, their email is returned instead of their username.
This is fixed. We now get the users object from db with the userid in the token. This always results in username for the poll.