### PR TITLE
Implementing Annotation Server

### DIFF
--- a/prediction-polls/annotations/.gitignore
+++ b/prediction-polls/annotations/.gitignore
@@ -1,0 +1,4 @@
+*.env
+node_modules/*
+package-lock.json
+.eslintrc.js

--- a/prediction-polls/annotations/config/swaggerOptions.js
+++ b/prediction-polls/annotations/config/swaggerOptions.js
@@ -1,0 +1,13 @@
+const swaggerOptions = {
+  definition: {
+    openapi: "3.0.0",
+    info: {
+      title: 'Prediction Poll API',
+      version: '1.0.0',
+      description: 'API Documentation for Prediction Poll API',
+    },
+  },
+  apis: ["./src/routes/*.js"], // Adjust this path to match your project structure
+};
+
+module.exports = swaggerOptions;

--- a/prediction-polls/annotations/package.json
+++ b/prediction-polls/annotations/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "annotations",
+  "version": "1.0.0",
+  "description": "",
+  "main": "app.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "start": "nodemon src/app.js"
+  },
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "body-parser": "^1.20.2",
+    "cors": "^2.8.5",
+    "dotenv": "^16.3.1",
+    "express": "^4.18.2",
+    "joi": "^17.11.0",
+    "mongodb": "^6.3.0",
+    "swagger-jsdoc": "^6.2.8",
+    "swagger-ui-express": "^5.0.0"
+  }
+}

--- a/prediction-polls/annotations/src/app.js
+++ b/prediction-polls/annotations/src/app.js
@@ -1,0 +1,28 @@
+const express = require('express');
+const cors = require("cors");
+const bodyParser = require('body-parser');
+
+require('dotenv').config();
+
+const annotationRouter = require('./routes/AnnotationRouter.js');
+
+const app = express();
+const port = 4999;
+
+app.use(cors());
+
+app.use(bodyParser.json());
+app.use(bodyParser.urlencoded({ extended: true })); 
+
+const swaggerJsDoc = require('swagger-jsdoc');
+const swaggerUi = require('swagger-ui-express');
+const swaggerOptions = require('../config/swaggerOptions.js');
+
+const swaggerSpec = swaggerJsDoc(swaggerOptions);
+app.use('/api-docs', swaggerUi.serve, swaggerUi.setup(swaggerSpec));
+
+app.use('/annotations', annotationRouter);
+
+app.listen(port, () => {
+  console.log(`Server is running on port ${port}`);
+});

--- a/prediction-polls/annotations/src/routes/AnnotationRouter.js
+++ b/prediction-polls/annotations/src/routes/AnnotationRouter.js
@@ -164,7 +164,11 @@ const contextService = require("../services/addContextService.js");
  *         modified:
  *           type: string
  *           description: The time at which the resource was modified, after creation. Often the same with "created". The datetime must be a xsd:dateTime with the UTC timezone expressed as "Z".
- *
+*/
+
+/**
+ * @swagger
+ * components:
  *   examples:
  *     Basic:
  *       value:
@@ -272,9 +276,82 @@ const contextService = require("../services/addContextService.js");
 
 /**
  * @swagger
+ * components:
+ *   examples:
+ *     PostBasic:
+ *       value:
+ *         target: /page1
+ *     PostWithBodyAndCreator:
+ *       value:
+ *         target: /page1
+ *         body: http://example.org/post1
+ *         creator: user1
+ *     PostEmbeddedTextBody:
+ *       value:
+ *         target: /page1
+ *         body: 
+ *           "type": TextualBody 
+ *           value: Example annotation content 
+ *           format: text/plain 
+ *         creator: user1
+ *     PostCSSSelector:
+ *       value:
+ *         target: 
+ *           source: "/page1.html"
+ *           selector: 
+ *             type: "CssSelector"
+ *             value: "#elemid > .elemclass + p"
+ *         body: 
+ *           "type": TextualBody 
+ *           value: Example annotation content 
+ *           format: text/plain 
+ *         creator: user1
+ *     PostXPathSelector:
+ *       value:
+ *         target: 
+ *           source: "/page1.html"
+ *           selector: 
+ *             type: "XPathSelector"
+ *             value: "/html/body/p[2]/table/tr[2]/td[3]/span"
+ *         body: 
+ *           "type": TextualBody 
+ *           value: Example annotation content 
+ *           format: text/plain 
+ *         creator: user1
+ *     PostTextQuoteSelector:
+ *       value:
+ *         target: 
+ *           source: "/page1"
+ *           selector: 
+ *             type: "TextQuoteSelector"
+ *             exact: "anotation"
+ *             prefix: "this is an "
+ *             suffix: " that has some"
+ *         body: 
+ *           "type": TextualBody 
+ *           value: "This seems to be a typo."
+ *           format: text/plain 
+ *         creator: user1
+ *     PostTextPositionSelector:
+ *       value:
+ *         target: 
+ *           source: "/page1"
+ *           selector: 
+ *             type: "TextPositionSelector"
+ *             start: 412
+ *             end: 795
+ *         body: 
+ *           "type": TextualBody 
+ *           value: "Example annotation content."
+ *           format: text/plain 
+ *         creator: user1
+ */
+
+/**
+ * @swagger
  * /annotations:
  *   get:
- *     summary: Returns the list of all Annotations
+ *     summary: Returns the list of Annotations according to query parameters
  *     responses:
  *       200:
  *         description: The list of the books retrieved successfully
@@ -312,6 +389,21 @@ router.get('/', service.getAnnotations);
  *         application/json:
  *           schema:
  *             $ref: "#/components/schemas/AnnotationPost"
+ *           examples:
+ *             Basic:
+ *               $ref: "#/components/examples/PostBasic" 
+ *             WithBodyAndCreator:
+ *               $ref: "#/components/examples/PostWithBodyAndCreator" 
+ *             EmbeddedTextBody:
+ *               $ref: "#/components/examples/PostEmbeddedTextBody" 
+ *             CSSSelector:
+ *               $ref: "#/components/examples/PostCSSSelector" 
+ *             XPathSelector:
+ *               $ref: "#/components/examples/PostXPathSelector" 
+ *             TextQuoteSelector:
+ *               $ref: "#/components/examples/PostTextQuoteSelector" 
+ *             TextPositionSelector:
+ *               $ref: "#/components/examples/PostTextPositionSelector" 
  *     responses:
  *       '200':
  *         description: Successfully created annotation

--- a/prediction-polls/annotations/src/routes/AnnotationRouter.js
+++ b/prediction-polls/annotations/src/routes/AnnotationRouter.js
@@ -381,6 +381,63 @@ router.get('/', service.getAnnotations);
 
 /**
  * @swagger
+ * /annotations/{id}:
+ *   get:
+ *     summary: Get an annotation by ID
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         description: The ID of the annotation
+ *         schema:
+ *           type: string
+ *     responses:
+ *       200:
+ *         description: The list of the books retrieved successfully
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: array
+ *               items: 
+ *                 $ref: "#/components/schemas/Annotation"
+ *             examples:
+ *               Basic:
+ *                 $ref: "#/components/examples/Basic" 
+ *               WithBodyAndCreator:
+ *                 $ref: "#/components/examples/WithBodyAndCreator" 
+ *               EmbeddedTextBody:
+ *                 $ref: "#/components/examples/EmbeddedTextBody" 
+ *               CSSSelector:
+ *                 $ref: "#/components/examples/CSSSelector" 
+ *               XPathSelector:
+ *                 $ref: "#/components/examples/XPathSelector" 
+ *               TextQuoteSelector:
+ *                 $ref: "#/components/examples/TextQuoteSelector" 
+ *               TextPositionSelector:
+ *                 $ref: "#/components/examples/TextPositionSelector" 
+ *       404:
+ *         description: Annotation not found
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 error:
+ *                   type: string
+ *       500:
+ *         description: Internal Server Error
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 error:
+ *                   type: string
+ */
+router.get('/:id', service.getAnnotationWithId);
+
+/**
+ * @swagger
  * /annotations:
  *   post:
  *     summary: Create a new annotation

--- a/prediction-polls/annotations/src/routes/AnnotationRouter.js
+++ b/prediction-polls/annotations/src/routes/AnnotationRouter.js
@@ -120,11 +120,15 @@ const contextService = require("../services/addContextService.js");
  *         target:
  *           $ref: "#/components/schemas/Target"
  *           required: true
+ *           description: The relationship between an Annotation and its Target
  *         body:
  *           $ref: "#/components/schemas/Body"
+ *           description: The relationship between an Annotation and its Body
  *         creator:
  *           type: string
  *           minLength: 1
+ *           description: The agent responsible for creating the resource
+ * 
  *     Annotation:
  *       type: object
  *       required:
@@ -145,66 +149,11 @@ const contextService = require("../services/addContextService.js");
  *           type: string
  *           description: The type of the Annotation
  *         target:
- *           oneOf:
- *             - type: string
- *             - type: object
- *               properties:
- *                 source: 
- *                   type: string
- *                   description: Source IRI of the resource
- *                 selector:
- *                   oneOf:
- *                     - type: object
- *                       properties:
- *                         "type": 
- *                            type: string
- *                            description: The class of the Selector
- *                         value:
- *                            type: string
- *                            description: The CSS selection path to the Segment OR The xpath to the selected segment
- *                     - type: object
- *                       properties:
- *                         "type": 
- *                            type: string
- *                            description: The class of the Selector
- *                         exact: 
- *                            type: string
- *                            description: A copy of the text which is being selected, after normalization
- *                         prefix: 
- *                            type: string
- *                            description: A snippet of text that occurs immediately before the text which is being selected
- *                         suffix: 
- *                            type: string
- *                            description: The snippet of text that occurs immediately after the text which is being selected.
- *                     - type: object
- *                       properties:
- *                         "type": 
- *                            type: string
- *                            description: The class of the Selector
- *                         start: 
- *                            type: integer
- *                            description: The starting position of the segment of text. The first character in the full text is character position 0, and the character is included within the segment
- *                         end: 
- *                            type: integer
- *                            description: The end position of the segment of text. The character is not included within the segment
- *                     
- *                   description: The relationship between a Specific Resource and a Selector.
- *                 
+ *           $ref: "#/components/schemas/Target"
+ *           required: true
  *           description: The relationship between an Annotation and its Target
  *         body:
- *           oneOf:
- *             - type: string
- *             - type: object
- *               properties:
- *                 "type":
- *                   type: string
- *                   description: The type of the Textual Body resource. The Body should have the TextualBody class
- *                 value:
- *                   type: string  
- *                   description: The character sequence of the content of the Textual Body  
- *                 format:
- *                   type: string  
- *                   description: The format of the Web Resource's content
+ *           $ref: "#/components/schemas/Body"
  *           description: The relationship between an Annotation and its Body
  *         creator:
  *           type: string

--- a/prediction-polls/annotations/src/routes/AnnotationRouter.js
+++ b/prediction-polls/annotations/src/routes/AnnotationRouter.js
@@ -1,0 +1,240 @@
+const router = require('express').Router();
+const service = require("../services/annotationService.js");
+const validation = require("../services/ValidationService.js");
+const timeService = require("../services/AddTimeService.js");
+const contextService = require("../services/addContextService.js");
+
+/**
+ * @swagger
+ * components:
+ *   schemas:
+ *     Annotation:
+ *       type: object
+ *       required:
+ *         - "@context"
+ *         - "id"
+ *         - "type"
+ *         - "target"
+ *         - "created"
+ *         - "modified"
+ *       properties:
+ *         "@context":
+ *           type: string
+ *           description: The Annotation jsonld
+ *         id:
+ *           type: string
+ *           description: The identity of the Annotation, an IRI
+ *         type:
+ *           type: string
+ *           description: The type of the Annotation
+ *         target:
+ *           oneOf:
+ *             - type: string
+ *             - type: object
+ *               properties:
+ *                 source: 
+ *                   type: string
+ *                   description: Source IRI of the resource
+ *                 selector:
+ *                   oneOf:
+ *                     - type: object
+ *                       properties:
+ *                         "type": 
+ *                            type: string
+ *                            description: The class of the Selector
+ *                         value:
+ *                            type: string
+ *                            description: The CSS selection path to the Segment OR The xpath to the selected segment
+ *                     - type: object
+ *                       properties:
+ *                         "type": 
+ *                            type: string
+ *                            description: The class of the Selector
+ *                         exact: 
+ *                            type: string
+ *                            description: A copy of the text which is being selected, after normalization
+ *                         prefix: 
+ *                            type: string
+ *                            description: A snippet of text that occurs immediately before the text which is being selected
+ *                         suffix: 
+ *                            type: string
+ *                            description: The snippet of text that occurs immediately after the text which is being selected.
+ *                     - type: object
+ *                       properties:
+ *                         "type": 
+ *                            type: string
+ *                            description: The class of the Selector
+ *                         start: 
+ *                            type: integer
+ *                            description: The starting position of the segment of text. The first character in the full text is character position 0, and the character is included within the segment
+ *                         end: 
+ *                            type: integer
+ *                            description: The end position of the segment of text. The character is not included within the segment
+ *                     
+ *                   description: The relationship between a Specific Resource and a Selector.
+ *                 
+ *           description: The relationship between an Annotation and its Target
+ *         body:
+ *           oneOf:
+ *             - type: string
+ *             - type: object
+ *               properties:
+ *                 "type":
+ *                   type: string
+ *                   description: The type of the Textual Body resource. The Body should have the TextualBody class
+ *                 value:
+ *                   type: string  
+ *                   description: The character sequence of the content of the Textual Body  
+ *                 format:
+ *                   type: string  
+ *                   description: The format of the Web Resource's content
+ *           description: The relationship between an Annotation and its Body
+ *         creator:
+ *           type: string
+ *           description: The agent responsible for creating the resource
+ *         created:
+ *           type: string
+ *           description: The time at which the resource was created. The datetime must be a xsd:dateTime with the UTC timezone expressed as "Z".
+ *         modified:
+ *           type: string
+ *           description: The time at which the resource was modified, after creation. Often the same with "created". The datetime must be a xsd:dateTime with the UTC timezone expressed as "Z".
+ *   examples:
+ *     Basic:
+ *       value:
+ *         "@context": http://www.w3.org/ns/anno.jsonld
+ *         id: http://example.org/anno1
+ *         type: Annotation
+ *         target: http://example.com/page1
+ *         created: 2023-12-10T20:06:46.123Z
+ *         modified: 2023-12-10T20:06:46.123Z
+ *     WithBodyAndCreator:
+ *       value:
+ *         "@context": http://www.w3.org/ns/anno.jsonld
+ *         id: http://example.org/anno1
+ *         type: Annotation
+ *         target: http://example.com/page1
+ *         body: http://example.org/post1
+ *         creator: user1
+ *         created: 2023-12-10T20:06:46.123Z
+ *         modified: 2023-12-10T20:06:46.123Z
+ *     EmbeddedTextBody:
+ *       value:
+ *         "@context": http://www.w3.org/ns/anno.jsonld
+ *         id: http://example.org/anno1
+ *         type: Annotation
+ *         target: http://example.com/page1
+ *         body: 
+ *           "type": TextualBody 
+ *           value: Example annotation content 
+ *           format: text/plain 
+ *         creator: user1
+ *         created: 2023-12-10T20:06:46.123Z
+ *         modified: 2023-12-10T20:06:46.123Z
+ *     CSSSelector:
+ *       value:
+ *         "@context": http://www.w3.org/ns/anno.jsonld
+ *         id: http://example.org/anno1
+ *         type: Annotation
+ *         target: 
+ *           source: "http://example.org/page1.html"
+ *           selector: 
+ *             type: "CssSelector"
+ *             value: "#elemid > .elemclass + p"
+ *         body: 
+ *           "type": TextualBody 
+ *           value: Example annotation content 
+ *           format: text/plain 
+ *         creator: user1
+ *         created: 2023-12-10T20:06:46.123Z
+ *         modified: 2023-12-10T20:06:46.123Z
+ *     XPathSelector:
+ *       value:
+ *         "@context": http://www.w3.org/ns/anno.jsonld
+ *         id: http://example.org/anno1
+ *         type: Annotation
+ *         target: 
+ *           source: "http://example.org/page1.html"
+ *           selector: 
+ *             type: "XPathSelector"
+ *             value: "/html/body/p[2]/table/tr[2]/td[3]/span"
+ *         body: 
+ *           "type": TextualBody 
+ *           value: Example annotation content 
+ *           format: text/plain 
+ *         creator: user1
+ *         created: 2023-12-10T20:06:46.123Z
+ *         modified: 2023-12-10T20:06:46.123Z
+ *     TextQuoteSelector:
+ *       value:
+ *         "@context": http://www.w3.org/ns/anno.jsonld
+ *         id: http://example.org/anno1
+ *         type: Annotation
+ *         target: 
+ *           source: "http://example.org/page1"
+ *           selector: 
+ *             type: "TextQuoteSelector"
+ *             exact: "anotation"
+ *             prefix: "this is an "
+ *             suffix: " that has some"
+ *         body: 
+ *           "type": TextualBody 
+ *           value: "This seems to be a typo."
+ *           format: text/plain 
+ *         creator: user1
+ *         created: 2023-12-10T20:06:46.123Z
+ *         modified: 2023-12-10T20:06:46.123Z
+ *     TextPositionSelector:
+ *       value:
+ *         "@context": http://www.w3.org/ns/anno.jsonld
+ *         id: http://example.org/anno1
+ *         type: Annotation
+ *         target: 
+ *           source: "http://example.org/page1"
+ *           selector: 
+ *             type: "TextPositionSelector"
+ *             start: 412
+ *             end: 795
+ *         body: 
+ *           "type": TextualBody 
+ *           value: "Example annotation content."
+ *           format: text/plain 
+ *         creator: user1
+ *         created: 2023-12-10T20:06:46.123Z
+ *         modified: 2023-12-10T20:06:46.123Z
+ */
+
+/**
+ * @swagger
+ * /annotations:
+ *   get:
+ *     summary: Returns the list of all Annotations
+ *     responses:
+ *       200:
+ *         description: The list of the books retrieved successfully
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: array
+ *               items: 
+ *                 $ref: "#/components/schemas/Annotation"
+ *             examples:
+ *               Basic:
+ *                 $ref: "#/components/examples/Basic" 
+ *               WithBodyAndCreator:
+ *                 $ref: "#/components/examples/WithBodyAndCreator" 
+ *               EmbeddedTextBody:
+ *                 $ref: "#/components/examples/EmbeddedTextBody" 
+ *               CSSSelector:
+ *                 $ref: "#/components/examples/CSSSelector" 
+ *               XPathSelector:
+ *                 $ref: "#/components/examples/XPathSelector" 
+ *               TextQuoteSelector:
+ *                 $ref: "#/components/examples/TextQuoteSelector" 
+ *               TextPositionSelector:
+ *                 $ref: "#/components/examples/TextPositionSelector" 
+ */
+router.get('/', service.getAllAnnotations);
+
+router.post('/', validation.validate, contextService.attachContext, timeService.attachTimestamp, service.createAnnotation);
+
+module.exports = router;

--- a/prediction-polls/annotations/src/routes/AnnotationRouter.js
+++ b/prediction-polls/annotations/src/routes/AnnotationRouter.js
@@ -349,6 +349,17 @@ const contextService = require("../services/addContextService.js");
 
 /**
  * @swagger
+ * components:
+ *   examples:
+ *     UpdatedBodyExample:
+ *       value: 
+ *         "type": TextualBody 
+ *         value: "Updated Annotation Body"
+ *         format: text/plain 
+ */
+
+/**
+ * @swagger
  * /annotations:
  *   get:
  *     summary: Returns the list of Annotations according to query parameters
@@ -479,6 +490,113 @@ router.get('/:id', service.getAnnotationWithId);
  *         description: Bad Request - Invalid input data
  */
 router.post('/', validation.validate, contextService.attachContext, timeService.attachTimestamp, service.createAnnotation);
+
+/**
+ * @swagger
+ * /annotations/{id}:
+ *   delete:
+ *     summary: Delete an annotation by ID
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         description: The ID of the annotation to be deleted
+ *         schema:
+ *           type: string
+ *     responses:
+ *       200:
+ *         description: Annotation deleted successfully
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 message:
+ *                   type: string
+ *       404:
+ *         description: Annotation not found
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 error:
+ *                   type: string
+ *       500:
+ *         description: Internal Server Error
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 error:
+ *                   type: string
+ */
+router.delete('/:id', service.deleteAnnotationWithId);
+
+/**
+ * @swagger
+ * /annotations/{id}:
+ *   patch:
+ *     summary: Update the body of an annotation by ID
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         description: The ID of the annotation to be updated
+ *         schema:
+ *           type: string
+ *     requestBody:
+ *       description: Updated body of the annotation
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             $ref: "#/components/schemas/Body"
+ *           examples:
+ *             BodyUpdateExample:
+ *               $ref: "#/components/examples/UpdatedBodyExample"
+ *     responses:
+ *       200:
+ *         description: Annotation updated successfully
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 message:
+ *                   type: string
+ *       400:
+ *         description: Bad Request - Invalid request body format
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: array
+ *               items:
+ *                 type: object
+ *                 properties:
+ *                   message:
+ *                     type: string
+ *       404:
+ *         description: Annotation not found
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 error:
+ *                   type: string
+ *       500:
+ *         description: Internal Server Error
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 error:
+ *                   type: string
+ */
+router.patch('/:id', validation.validatePatchBody, service.patchAnnotationWithId);
 
 
 module.exports = router;

--- a/prediction-polls/annotations/src/routes/AnnotationRouter.js
+++ b/prediction-polls/annotations/src/routes/AnnotationRouter.js
@@ -352,6 +352,17 @@ const contextService = require("../services/addContextService.js");
  * /annotations:
  *   get:
  *     summary: Returns the list of Annotations according to query parameters
+ *     parameters:
+ *       - in: query
+ *         name: creator
+ *         schema:
+ *           type: string
+ *         description: The creator of the Annotation
+ *       - in: query
+ *         name: source
+ *         schema:
+ *           type: string
+ *         description: The source of the Target of the Annotations
  *     responses:
  *       200:
  *         description: The list of the books retrieved successfully

--- a/prediction-polls/annotations/src/routes/AnnotationRouter.js
+++ b/prediction-polls/annotations/src/routes/AnnotationRouter.js
@@ -8,6 +8,123 @@ const contextService = require("../services/addContextService.js");
  * @swagger
  * components:
  *   schemas:
+ *     TextPositionSelector:
+ *       type: object
+ *       properties:
+ *         type:
+ *           type: string
+ *           enum: [TextPositionSelector]
+ *           required: true
+ *         start:
+ *           type: number
+ *           required: true
+ *         end:
+ *           type: number
+ *           required: true
+ *
+ *     TextQuoteSelector:
+ *       type: object
+ *       properties:
+ *         type:
+ *           type: string
+ *           enum: [TextQuoteSelector]
+ *           required: true
+ *         exact:
+ *           type: string
+ *           required: true
+ *         prefix:
+ *           type: string
+ *           required: true
+ *         suffix:
+ *           type: string
+ *           required: true
+ *
+ *     XPathSelector:
+ *       type: object
+ *       properties:
+ *         type:
+ *           type: string
+ *           enum: [XPathSelector]
+ *           required: true
+ *         value:
+ *           type: string
+ *           required: true
+ *
+ *     CssSelector:
+ *       type: object
+ *       properties:
+ *         type:
+ *           type: string
+ *           enum: [CssSelector]
+ *           required: true
+ *         value:
+ *           type: string
+ *           required: true
+ *
+ *     Selector:
+ *       oneOf:
+ *         - $ref: "#/components/schemas/TextPositionSelector"
+ *         - $ref: "#/components/schemas/TextQuoteSelector"
+ *         - $ref: "#/components/schemas/XPathSelector"
+ *         - $ref: "#/components/schemas/CssSelector"
+ *
+ *     TargetUri:
+ *       type: string
+ *       format: uri
+ *       required: true
+ *
+ *     TargetObject:
+ *       type: object
+ *       properties:
+ *         source:
+ *           type: string
+ *           format: uri
+ *           required: true
+ *         selector:
+ *           $ref: "#/components/schemas/Selector"
+ *           required: true
+ *
+ *     Target:
+ *       oneOf:
+ *         - $ref: "#/components/schemas/TargetUri"
+ *         - $ref: "#/components/schemas/TargetObject"
+ *
+ *     BodyUri:
+ *       type: string
+ *       format: uri
+ *       required: true
+ *
+ *     BodyObject:
+ *       type: object
+ *       properties:
+ *         type:
+ *           type: string
+ *           enum: [TextualBody]
+ *           required: true
+ *         value:
+ *           type: string
+ *           required: true
+ *         format:
+ *           type: string
+ *           enum: [text/plain]
+ *           required: true
+ *
+ *     Body:
+ *       oneOf:
+ *         - $ref: "#/components/schemas/BodyUri"
+ *         - $ref: "#/components/schemas/BodyObject"
+ *
+ *     AnnotationPost:
+ *       type: object
+ *       properties:
+ *         target:
+ *           $ref: "#/components/schemas/Target"
+ *           required: true
+ *         body:
+ *           $ref: "#/components/schemas/Body"
+ *         creator:
+ *           type: string
+ *           minLength: 1
  *     Annotation:
  *       type: object
  *       required:
@@ -98,6 +215,7 @@ const contextService = require("../services/addContextService.js");
  *         modified:
  *           type: string
  *           description: The time at which the resource was modified, after creation. Often the same with "created". The datetime must be a xsd:dateTime with the UTC timezone expressed as "Z".
+ *
  *   examples:
  *     Basic:
  *       value:
@@ -235,6 +353,23 @@ const contextService = require("../services/addContextService.js");
  */
 router.get('/', service.getAllAnnotations);
 
+/**
+ * @swagger
+ * /annotations:
+ *   post:
+ *     summary: Create a new annotation
+ *     requestBody:
+ *       content:
+ *         application/json:
+ *           schema:
+ *             $ref: "#/components/schemas/AnnotationPost"
+ *     responses:
+ *       '200':
+ *         description: Successfully created annotation
+ *       '400':
+ *         description: Bad Request - Invalid input data
+ */
 router.post('/', validation.validate, contextService.attachContext, timeService.attachTimestamp, service.createAnnotation);
+
 
 module.exports = router;

--- a/prediction-polls/annotations/src/routes/AnnotationRouter.js
+++ b/prediction-polls/annotations/src/routes/AnnotationRouter.js
@@ -300,7 +300,7 @@ const contextService = require("../services/addContextService.js");
  *               TextPositionSelector:
  *                 $ref: "#/components/examples/TextPositionSelector" 
  */
-router.get('/', service.getAllAnnotations);
+router.get('/', service.getAnnotations);
 
 /**
  * @swagger

--- a/prediction-polls/annotations/src/services/AddContextService.js
+++ b/prediction-polls/annotations/src/services/AddContextService.js
@@ -3,7 +3,7 @@ const url = require('url');
 async function attachContext(req, res, next) {
   req.body["@context"] = "http://www.w3.org/ns/anno.jsonld";
   if (typeof req.body.target === 'string') {
-    req.body.target = url.resolve(process.env.APP_URI, req.body.target);;
+    req.body.target = url.resolve(process.env.APP_URI, req.body.target);
   } else if (typeof req.body.target === 'object') {
     req.body.target.source = url.resolve(process.env.APP_URI, req.body.target.source);
   }

--- a/prediction-polls/annotations/src/services/AddContextService.js
+++ b/prediction-polls/annotations/src/services/AddContextService.js
@@ -1,0 +1,7 @@
+async function attachContext(req, res, next) {
+  req.body["@context"] = "http://www.w3.org/ns/anno.jsonld";
+  req.body.type = "Annotation";
+  next();
+}
+
+module.exports = {attachContext};

--- a/prediction-polls/annotations/src/services/AddContextService.js
+++ b/prediction-polls/annotations/src/services/AddContextService.js
@@ -1,5 +1,10 @@
 async function attachContext(req, res, next) {
   req.body["@context"] = "http://www.w3.org/ns/anno.jsonld";
+  if (typeof req.body.target === 'string') {
+    req.body.target = process.env.APP_URI + req.body.target;
+  } else if (typeof req.body.target === 'object') {
+    req.body.target.source = process.env.APP_URI + req.body.target.source;
+  }
   req.body.type = "Annotation";
   next();
 }

--- a/prediction-polls/annotations/src/services/AddContextService.js
+++ b/prediction-polls/annotations/src/services/AddContextService.js
@@ -1,9 +1,11 @@
+const url = require('url');
+
 async function attachContext(req, res, next) {
   req.body["@context"] = "http://www.w3.org/ns/anno.jsonld";
   if (typeof req.body.target === 'string') {
-    req.body.target = process.env.APP_URI + req.body.target;
+    req.body.target = url.resolve(process.env.APP_URI, req.body.target);;
   } else if (typeof req.body.target === 'object') {
-    req.body.target.source = process.env.APP_URI + req.body.target.source;
+    req.body.target.source = url.resolve(process.env.APP_URI, req.body.target.source);
   }
   req.body.type = "Annotation";
   next();

--- a/prediction-polls/annotations/src/services/AddTimeService.js
+++ b/prediction-polls/annotations/src/services/AddTimeService.js
@@ -1,0 +1,7 @@
+async function attachTimestamp(req, res, next) {
+  req.body.created = new Date().toISOString();
+  req.body.modified = new Date().toISOString();
+  next();
+}
+
+module.exports = { attachTimestamp };

--- a/prediction-polls/annotations/src/services/AnnotationService.js
+++ b/prediction-polls/annotations/src/services/AnnotationService.js
@@ -86,4 +86,57 @@ async function createAnnotation(req, res) {
   }
 }
 
-module.exports = { getAnnotations, createAnnotation, getAnnotationWithId };
+async function deleteAnnotationWithId(req, res) {
+  const annotationId = req.params.id;
+
+  try {
+    await client.connect();
+
+    const database = client.db(process.env.MONGO_DB);
+    const collection = database.collection(process.env.MONGO_COLLECTION);
+
+    const result = await collection.deleteOne({ id: new RegExp(`.*${annotationId}$`) });
+
+    if (result.deletedCount === 0) {
+      return res.status(404).json({ error: 'Annotation not found' });
+    }
+
+    client.close();
+
+    res.json({ message: 'Annotation deleted successfully' });
+  } catch (error) {
+    console.error('Error deleting annotation:', error);
+    res.status(500).json({ error: 'Internal Server Error' });
+  }
+}
+
+async function patchAnnotationWithId(req, res) {
+  const annotationId = req.params.id;
+  const updatedBody = req.body;
+
+  try {
+    await client.connect();
+
+    const database = client.db(process.env.MONGO_DB);
+    const collection = database.collection(process.env.MONGO_COLLECTION);
+
+    const result = await collection.updateOne(
+      { id: new RegExp(`.*${annotationId}$`) },
+      { $set: { body: updatedBody } }
+    );
+
+    if (result.matchedCount === 0) {
+      return res.status(404).json({ error: 'Annotation not found' });
+    }
+
+    client.close();
+
+    res.json({ message: 'Annotation updated successfully' });
+  } catch (error) {
+    console.error('Error updating annotation:', error);
+    res.status(500).json({ error: 'Internal Server Error' });
+  }
+}
+
+
+module.exports = { getAnnotations, createAnnotation, getAnnotationWithId, deleteAnnotationWithId, patchAnnotationWithId };

--- a/prediction-polls/annotations/src/services/AnnotationService.js
+++ b/prediction-polls/annotations/src/services/AnnotationService.js
@@ -39,6 +39,30 @@ async function getAnnotations(req, res) {
   }
 }
 
+async function getAnnotationWithId(req, res) {
+  const annotationId = req.params.id;
+
+  try {
+    await client.connect();
+
+    const database = client.db(process.env.MONGO_DB);
+    const collection = database.collection(process.env.MONGO_COLLECTION);
+
+    const annotation = await collection.findOne({ id: new RegExp(`.*${annotationId}$`) }, {projection: {"_id": 0}});
+
+    if (!annotation) {
+      return res.status(404).json({ error: 'Annotation not found' });
+    }
+
+    client.close();
+
+    res.json(annotation);
+  } catch (error) {
+    console.error('Error fetching annotations:', error);
+    res.status(500).json({ error: 'Internal Server Error' });
+  }
+}
+
 async function createAnnotation(req, res) {
   try {
     await client.connect();
@@ -62,4 +86,4 @@ async function createAnnotation(req, res) {
   }
 }
 
-module.exports = { getAnnotations, createAnnotation };
+module.exports = { getAnnotations, createAnnotation, getAnnotationWithId };

--- a/prediction-polls/annotations/src/services/AnnotationService.js
+++ b/prediction-polls/annotations/src/services/AnnotationService.js
@@ -9,14 +9,25 @@ const client = new MongoClient(process.env.MONGO_URI, {
   }
 });
 
-async function getAllAnnotations(req, res) {
+async function getAnnotations(req, res) {
+  const { creator, source } = req.query;
+  let filter = {};
+
+  if (creator) {
+    filter.creator = creator;
+  }
+
+  if (source) {
+    filter['target.source'] = source;
+  }
+
   try {
     await client.connect();
 
     const database = client.db(process.env.MONGO_DB);
     const collection = database.collection(process.env.MONGO_COLLECTION);
 
-    const annotations = await collection.find({}, { projection: { _id: 0 } }).toArray();
+    const annotations = await collection.find(filter, { projection: { _id: 0 } }).toArray();
 
     client.close();
 
@@ -42,4 +53,4 @@ async function createAnnotation(req, res) {
   }
 }
 
-module.exports = { getAllAnnotations, createAnnotation };
+module.exports = { getAnnotations, createAnnotation };

--- a/prediction-polls/annotations/src/services/AnnotationService.js
+++ b/prediction-polls/annotations/src/services/AnnotationService.js
@@ -1,0 +1,45 @@
+const { MongoClient, ServerApiVersion } = require('mongodb');
+require('dotenv').config();
+
+const client = new MongoClient(process.env.MONGO_URI, {
+  serverApi: {
+    version: ServerApiVersion.v1,
+    strict: true,
+    deprecationErrors: true,
+  }
+});
+
+async function getAllAnnotations(req, res) {
+  try {
+    await client.connect();
+
+    const database = client.db(process.env.MONGO_DB);
+    const collection = database.collection(process.env.MONGO_COLLECTION);
+
+    const annotations = await collection.find({}, { projection: { _id: 0 } }).toArray();
+
+    client.close();
+
+    res.json(annotations);
+  } catch (error) {
+    console.error('Error fetching annotations:', error);
+    res.status(500).json({ error: 'Internal Server Error' });
+  }
+}
+
+async function createAnnotation(req, res) {
+  try {
+    await client.connect();
+    const database = client.db(process.env.MONGO_DB);
+    const collection = database.collection(process.env.MONGO_COLLECTION);
+
+    const result = await collection.insertOne(req.body);
+
+    res.status(200).json({success: true});
+  } catch (error) {
+    console.log(error);
+    res.status(500).json({error: error})
+  }
+}
+
+module.exports = { getAllAnnotations, createAnnotation };

--- a/prediction-polls/annotations/src/services/ValidationService.js
+++ b/prediction-polls/annotations/src/services/ValidationService.js
@@ -56,7 +56,7 @@ const annotationPostSchema = Joi.object({
 });
 
 async function validate(req, res, next) {
-  const {error, value} = annotationPostSchema.validate(req.body, {abortEarly: false});
+  const {error, value} = annotationPostSchema.validate(req.body);
 
   if (error) {
     console.log(error.details);

--- a/prediction-polls/annotations/src/services/ValidationService.js
+++ b/prediction-polls/annotations/src/services/ValidationService.js
@@ -2,8 +2,8 @@ const Joi = require("joi");
 
 const textPositionSelectorSchema = Joi.object({
   type: Joi.string().valid('TextPositionSelector').required(),
-  start: Joi.number().required(),
-  end: Joi.number().required(),
+  start: Joi.number().integer().positive().required(),
+  end: Joi.number().integer().positive().min(Joi.ref('start')).required(),
 });
 
 const textQuoteSelectorSchema = Joi.object({

--- a/prediction-polls/annotations/src/services/ValidationService.js
+++ b/prediction-polls/annotations/src/services/ValidationService.js
@@ -1,0 +1,68 @@
+const Joi = require("joi");
+
+const textPositionSelectorSchema = Joi.object({
+  type: Joi.string().valid('TextPositionSelector').required(),
+  start: Joi.number().required(),
+  end: Joi.number().required(),
+});
+
+const textQuoteSelectorSchema = Joi.object({
+  type: Joi.string().valid('TextQuoteSelector').required(),
+  exact: Joi.string().required(),
+  prefix: Joi.string().required(),
+  suffix: Joi.string().required(),
+});
+
+const xPathSelectorSchema = Joi.object({
+  type: Joi.string().valid('XPathSelector').required(),
+  value: Joi.string().required(),
+});
+
+const cssSelectorSchema = Joi.object({
+  type: Joi.string().valid('CssSelector').required(),
+  value: Joi.string().required(),
+});
+
+const selectorSchema = Joi.alternatives().try(
+  textPositionSelectorSchema,
+  textQuoteSelectorSchema,
+  xPathSelectorSchema,
+  cssSelectorSchema
+);
+
+const targetUriSchema = Joi.string().uri().required();
+
+const targetObjectSchema = Joi.object({
+  source: Joi.string().uri().required(),
+  selector: selectorSchema.required(),
+});
+
+const targetSchema = Joi.alternatives().try(targetUriSchema, targetObjectSchema);
+
+const bodyUriSchema = Joi.string().uri().required();
+
+const bodyObjectSchema = Joi.object({
+  type: Joi.string().valid("TextualBody").required(),
+  value: Joi.string().required(),
+  format: Joi.string().valid("text/plain").required()
+});
+
+const bodySchema = Joi.alternatives().try(bodyUriSchema, bodyObjectSchema);
+
+const annotationPostSchema = Joi.object({
+  target: targetSchema.required(),
+  body: bodySchema,
+  creator: Joi.string().min(1)
+});
+
+async function validate(req, res, next) {
+  const {error, value} = annotationPostSchema.validate(req.body, {abortEarly: false});
+
+  if (error) {
+    console.log(error.details);
+    return res.status(400).json(error.details);
+  }
+  next();
+}
+
+module.exports = { validate };

--- a/prediction-polls/annotations/src/services/ValidationService.js
+++ b/prediction-polls/annotations/src/services/ValidationService.js
@@ -30,10 +30,10 @@ const selectorSchema = Joi.alternatives().try(
   cssSelectorSchema
 );
 
-const targetUriSchema = Joi.string().uri().required();
+const targetUriSchema = Joi.string().uri({relativeOnly: true}).required();
 
 const targetObjectSchema = Joi.object({
-  source: Joi.string().uri().required(),
+  source: Joi.string().uri({relativeOnly: true}).required(),
   selector: selectorSchema.required(),
 });
 

--- a/prediction-polls/annotations/src/services/ValidationService.js
+++ b/prediction-polls/annotations/src/services/ValidationService.js
@@ -65,4 +65,14 @@ async function validate(req, res, next) {
   next();
 }
 
-module.exports = { validate };
+async function validatePatchBody(req, res, next) {
+  const {error, value} = bodySchema.validate(req.body);
+
+  if (error) {
+    console.log(error.details);
+    return res.status(400).json(error.details);
+  }
+  next();
+}
+
+module.exports = { validate, validatePatchBody };


### PR DESCRIPTION
This PR is the first attempt at implementing an annotation server.

We use MongoDB in the back for storing JSON objects (JSON-LD to be specific).

We have 5 endpoints:

- GET /annotations
You get all annotations if you pass no query parameters. Or optionally, you provide "creator" parameter to get the annotations created by that user. Or you can query the "source" property. This is the target resource of the annotation. With this, you can for example get all annotations for a specific URL like "www.prediction-polls.com/polls/5" etc. Combining these two, you can get a specific user's annotations on a page.

- Get /annotations/{id}
Same with above, returns one Annotation, you get the Annotation with the specified id. You can find this value from the end of the "id" value of the annotation. This value is given to the object automatically by MongoDB, so, I am using it.

- POST /annotations
I won't explain this in detail here. You can check the swagger documentation. Just note that you don't need to pass everything in the standardized JSON-LD format. You MUST pass a "target" value. You SHOULD pass a "body" value. And you SHOULD pass a "creator" value (although we may have a different solution including pulling the userid from JWT tokens maybe, but for now, the party that POST request is responsible with including a "creator" value. Again, this might change.)

- DELETE /annotations/{id}
Self explanatory, deletes annotation with the specified id. The talk about "id" above applies to this aswell.

- PATCH /annotations/{id}
Updates an existing Annotation. You are only allowed to change the content of the "body" property. This is enforced by validation. So only send valid "body" objects. See swagger for details.

I hope we can deploy this as soon as possible. So other teams can see the swagger documentation easily.

For now, we support these types of Selectors for selecting content to annotate:

- [CSSSelector](https://www.w3.org/TR/annotation-model/#css-selector)
- [XPathSelector](https://www.w3.org/TR/annotation-model/#xpath-selector)
- [TextQuoteSelector](https://www.w3.org/TR/annotation-model/#text-quote-selector)
- [TextPositionSelector](https://www.w3.org/TR/annotation-model/#text-position-selector)

You can use any one of them to select specific parts of your target. If you need Annotation server to support another type of Selector, let (@Sefik-Palazoglu ) know.

Some ./env values that I use in this part
MONGO_URI=mongodb://localhost:27017/appdb
MONGO_DB=appdb
MONGO_COLLECTION=annos
APP_URI=http://ec2-3-78-169-139.eu-central-1.compute.amazonaws.com:3000
ANNOTATION_URI=http://localhost:4999

APP_URI is the URI for our frontend app, which can be annotated.
ANNOTATION_URI is supposed to be where our Annotation server lives and where we send requests mentioned above.

closes #494 