### PR TITLE
Implementation of leaderboard data

### DIFF
--- a/prediction-polls/backend/src/repositories/AuthorizationDB.js
+++ b/prediction-polls/backend/src/repositories/AuthorizationDB.js
@@ -252,9 +252,6 @@ async function decrementUserParticipate(userId){
         throw error;
     }
 }
-
-
-
 module.exports = {pool, addRefreshToken,checkRefreshToken,deleteRefreshToken,isUsernameOrEmailInUse,checkCredentials,addUser,findUser,
     saveEmailVerificationToken,verifyEmailToken,createTransporter,storePasswordResetToken,getUserByResetToken,updateUserPassword,
     clearResetToken,updateUserLastLogin,incrementUserParticipate,decrementUserParticipate

--- a/prediction-polls/backend/src/repositories/AuthorizationDB.js
+++ b/prediction-polls/backend/src/repositories/AuthorizationDB.js
@@ -252,6 +252,9 @@ async function decrementUserParticipate(userId){
         throw error;
     }
 }
+
+
+
 module.exports = {pool, addRefreshToken,checkRefreshToken,deleteRefreshToken,isUsernameOrEmailInUse,checkCredentials,addUser,findUser,
     saveEmailVerificationToken,verifyEmailToken,createTransporter,storePasswordResetToken,getUserByResetToken,updateUserPassword,
     clearResetToken,updateUserLastLogin,incrementUserParticipate,decrementUserParticipate

--- a/prediction-polls/backend/src/repositories/ProfileDB.js
+++ b/prediction-polls/backend/src/repositories/ProfileDB.js
@@ -284,7 +284,7 @@ async function followerProfiles(userId) {
 }
 async function getRankPerTag(topic){
     try {
-        const query = 'SELECT user.id , user.username has_domain_point.amount from user, has_domain_point where user.id = has_domain_point.userID AND has_domain_point.topic = ? Order By has_domain_point.amount Desc LIMIT 100';
+        const query = 'SELECT users.id , users.username has_domain_point.amount from user, has_domain_point where user.id = has_domain_point.userId AND has_domain_point.topic = ? Order By has_domain_point.amount Desc LIMIT 100';
         const [result] = await pool.query(query, [topic]);
         return {result: result};
     } catch (error) {

--- a/prediction-polls/backend/src/repositories/ProfileDB.js
+++ b/prediction-polls/backend/src/repositories/ProfileDB.js
@@ -284,7 +284,7 @@ async function followerProfiles(userId) {
 }
 async function getRankPerTag(topic){
     try {
-        const query = 'SELECT users.id , users.username has_domain_point.amount from users, has_domain_point where users.id = has_domain_point.userId AND has_domain_point.topic = ? Order By has_domain_point.amount Desc LIMIT 100';
+        const query = 'SELECT users.id , users.username, has_domain_point.amount from users, has_domain_point where users.id = has_domain_point.userId AND has_domain_point.topic = ? Order By has_domain_point.amount Desc LIMIT 100';
         const [result] = await pool.query(query, [topic]);
         return {result: result};
     } catch (error) {

--- a/prediction-polls/backend/src/repositories/ProfileDB.js
+++ b/prediction-polls/backend/src/repositories/ProfileDB.js
@@ -284,7 +284,7 @@ async function followerProfiles(userId) {
 }
 async function getRankPerTag(topic){
     try {
-        const query = 'SELECT users.id , users.username has_domain_point.amount from user, has_domain_point where user.id = has_domain_point.userId AND has_domain_point.topic = ? Order By has_domain_point.amount Desc LIMIT 100';
+        const query = 'SELECT users.id , users.username has_domain_point.amount from users, has_domain_point where users.id = has_domain_point.userId AND has_domain_point.topic = ? Order By has_domain_point.amount Desc LIMIT 100';
         const [result] = await pool.query(query, [topic]);
         return {result: result};
     } catch (error) {

--- a/prediction-polls/backend/src/repositories/ProfileDB.js
+++ b/prediction-polls/backend/src/repositories/ProfileDB.js
@@ -282,5 +282,30 @@ async function followerProfiles(userId) {
         return { error: errorCodes.DATABASE_ERROR };
     }
 }
+async function getRankPerTag(topic){
+    try {
+        const query = 'SELECT user.id , user.username has_domain_point.amount from user, has_domain_point where user.id = has_domain_point.userID AND has_domain_point.topic = ? Order By has_domain_point.amount Desc LIMIT 100';
+        const [result] = await pool.query(query, [topic]);
+        return {result: result};
+    } catch (error) {
+        return { error: errorCodes.DATABASE_ERROR };
+    }
+}
 
-module.exports = { getProfileWithProfileId, getProfileWithUserId, addProfile, updateProfile, getBadges, updateBadge, updatePoints, followProfile, unfollowProfile, followerProfiles, followedProfiles }
+async function updateBadges(userId){
+    try {
+        const query = 'SELECT userId, topic, RANK() OVER (PARTITION BY topic ORDER BY amount DESC) as userRank FROM has_domain_point where userRank > 4';
+        const [result] = await pool.query(query, [userId]);
+        const deleteQuery = 'DELETE FROM badges';
+        const [_] = await pool.query(deleteQuery, []);
+        const insertQuery = 'INSERT INTO badges (userRank, topic, userId) VALUES (?, ?, ?)'
+        result.map(async (row)=>{
+            const [result] = await pool.query(insertQuery, [row.userRank,row.topic,row.userId]);
+        })
+        return {result: "Success"};
+    } catch (error) {
+        return { error: errorCodes.DATABASE_ERROR };
+    }
+}
+
+module.exports = { getProfileWithProfileId, getProfileWithUserId, addProfile, updateProfile, getBadges, updateBadge, updatePoints, followProfile, unfollowProfile, followerProfiles, followedProfiles,getRankPerTag,updateBadges }

--- a/prediction-polls/backend/src/routes/ProfileRouter.js
+++ b/prediction-polls/backend/src/routes/ProfileRouter.js
@@ -520,6 +520,6 @@ router.post('/follower',authenticator.authorizeAccessToken,service.getFollowerPr
  *                     message: Given data is not sufficient. Please follow guidelines.
  */
 
-router.post('/leaderboard/{topic}',service.getLeaderBoardRanking)
+router.get('/leaderboard/{topic}',service.getLeaderBoardRanking)
 
 module.exports = router;

--- a/prediction-polls/backend/src/routes/ProfileRouter.js
+++ b/prediction-polls/backend/src/routes/ProfileRouter.js
@@ -479,7 +479,7 @@ router.post('/follower',authenticator.authorizeAccessToken,service.getFollowerPr
 
 /**
  * @swagger
- * /leaderboard/{topic}:
+ * profiles/leaderboard/{topic}:
  *   get:
  *     tags:
  *       - profiles

--- a/prediction-polls/backend/src/routes/ProfileRouter.js
+++ b/prediction-polls/backend/src/routes/ProfileRouter.js
@@ -477,4 +477,49 @@ router.post('/followed',authenticator.authorizeAccessToken,service.getFollowedPr
  */
 router.post('/follower',authenticator.authorizeAccessToken,service.getFollowerProfiles)
 
+/**
+ * @swagger
+ * /leaderboard/{topic}:
+ *   get:
+ *     tags:
+ *       - profiles
+ *     description: Get the top scoring users given a topic.
+ *     parameters:
+ *       - in: path
+ *         name: topic
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: The name of a topic.
+ *     responses:
+ *       200:
+ *         description: Successful response
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 userList:
+ *                   type: array
+ *       400:
+ *         description: Bad Request
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 message:
+ *                   type: string
+ *                 code:
+ *                   type: integer
+ *             examples:
+ *               INSUFFICIENT_DATA:
+ *                 value:
+ *                   error:
+ *                     code: 1007,
+ *                     message: Given data is not sufficient. Please follow guidelines.
+ */
+
+router.post('/leaderboard/{topic}',service.getLeaderBoardRanking)
+
 module.exports = router;

--- a/prediction-polls/backend/src/routes/ProfileRouter.js
+++ b/prediction-polls/backend/src/routes/ProfileRouter.js
@@ -520,6 +520,6 @@ router.post('/follower',authenticator.authorizeAccessToken,service.getFollowerPr
  *                     message: Given data is not sufficient. Please follow guidelines.
  */
 
-router.get('/leaderboard/{topic}',service.getLeaderBoardRanking)
+router.get('/leaderboard/:topic',service.getLeaderBoardRanking)
 
 module.exports = router;

--- a/prediction-polls/backend/src/schema.sql
+++ b/prediction-polls/backend/src/schema.sql
@@ -161,3 +161,11 @@ CREATE TABLE user_follow (
     FOREIGN KEY (follower_id) REFERENCES profiles(userId) ON DELETE CASCADE
     FOREIGN KEY (followed_id) REFERENCES profiles(userId) ON DELETE CASCADE
 );
+
+CREATE TABLE has_domain_point (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    topic VARCHAR(255) NOT NULL,
+    userId INT NOT NULL,
+    amount INT NOT NULL DEFAULT 0,
+    FOREIGN KEY (userId) REFERENCES users(id) ON DELETE SET NULL
+);

--- a/prediction-polls/backend/src/schema.sql
+++ b/prediction-polls/backend/src/schema.sql
@@ -167,5 +167,5 @@ CREATE TABLE has_domain_point (
     topic VARCHAR(255) NOT NULL,
     userId INT NOT NULL,
     amount INT NOT NULL DEFAULT 0,
-    FOREIGN KEY (userId) REFERENCES users(id) ON DELETE SET NULL
+    FOREIGN KEY (userId) REFERENCES users(id)
 );

--- a/prediction-polls/backend/src/services/ProfileService.js
+++ b/prediction-polls/backend/src/services/ProfileService.js
@@ -280,5 +280,22 @@ async function getFollowedProfiles(req, res) {
     }
 }
 
+async function getLeaderBoardRanking(req, res) {
+    const topic = req.params.topic;
 
-module.exports = { getProfile, getProfileWithProfileId, getMyProfile, updateProfile, uploadImagetoS3, updateBadge, followProfiles, unfollowProfiles,getFollowerProfiles, getFollowedProfiles }
+    if (topic == undefined) {
+        return res.status(400).json({ error: errorCodes.INSUFFICIENT_DATA });
+    }
+    try {
+        const { result, error } = await db.getRankPerTag(topic);
+        if (error) {
+            throw error;
+        }
+        return res.status(200).json({ userList : result });
+    } catch (error) {
+        return res.status(400).json({ error: error });
+    }
+}
+
+
+module.exports = { getProfile, getProfileWithProfileId, getMyProfile, updateProfile, uploadImagetoS3, updateBadge, followProfiles, unfollowProfiles, getFollowerProfiles, getFollowedProfiles, getLeaderBoardRanking }


### PR DESCRIPTION
I have implemented:
1- updateBadges in ProfileDB:
Updates the badge table based on the updated scores in the has_domain_point table
2- getRankPerTag in ProfileDB:
Retrieves the top 100 scoring users given a topic string input. Associated service functions and endpoints with their swagger documentation are implemented!
The new endpoint is /leaderboard/{topic}