### PR TITLE
frontend/test/not-moderator-page

### DIFF
--- a/prediction-polls/frontend/package-lock.json
+++ b/prediction-polls/frontend/package-lock.json
@@ -22,7 +22,8 @@
         "react-router-dom": "^6.16.0",
         "react-scripts": "5.0.1",
         "react-share": "^5.0.3",
-        "web-vitals": "^2.1.4"
+        "web-vitals": "^2.1.4",
+        "@babel/plugin-proposal-private-property-in-object": "^1.0.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/prediction-polls/frontend/package.json
+++ b/prediction-polls/frontend/package.json
@@ -17,7 +17,8 @@
     "react-router-dom": "^6.16.0",
     "react-scripts": "5.0.1",
     "react-share": "^5.0.3",
-    "web-vitals": "^2.1.4"
+    "web-vitals": "^2.1.4",
+    "@babel/plugin-proposal-private-property-in-object": "^1.0.0"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/prediction-polls/frontend/src/Pages/Moderation/NotModerator.test.js
+++ b/prediction-polls/frontend/src/Pages/Moderation/NotModerator.test.js
@@ -1,0 +1,46 @@
+import React from 'react';
+import { render, fireEvent, screen } from '@testing-library/react';
+import Moderation from './index.jsx';
+import { MemoryRouter } from 'react-router-dom';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom/extend-expect'; 
+
+
+describe('Moderation', () => {
+    test('renders the non-moderator view correctly', () => {
+        render(
+            <MemoryRouter>
+              <Moderation />
+            </MemoryRouter>
+          );
+  
+      
+      expect(screen.getByText('Would you like to apply to become a moderator?')).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Apply' })).toBeInTheDocument();
+    });
+  
+    test('handles the "apply to become a moderator" button click', async () => {
+        render(
+            <MemoryRouter>
+              <Moderation />
+            </MemoryRouter>
+          );
+  
+      
+      const mockApiCall = jest.fn(() => Promise.resolve());
+  
+      
+      jest.spyOn(global, 'fetch').mockImplementation(mockApiCall);
+  
+      // Trigger the button click
+      userEvent.click(screen.getByRole('button', { name: 'Apply' }));
+  
+      
+      expect(mockApiCall).toHaveBeenCalledTimes(1);
+  
+      // Clean up the mock after the test
+      global.fetch.mockRestore();
+    });
+  
+  });
+

--- a/prediction-polls/frontend/src/Pages/Moderation/index.jsx
+++ b/prediction-polls/frontend/src/Pages/Moderation/index.jsx
@@ -125,6 +125,10 @@ function Moderation() {
           },
         });
 
+        if (!response) {
+          throw new Error("API response is undefined");
+        }
+
         if (!response.ok) {
           throw new Error("Network response was not ok");
         }
@@ -151,6 +155,10 @@ function Moderation() {
             "Content-Type": "application/json",
           },
         });
+
+        if (!response) {
+          throw new Error("API response is undefined");
+        }
 
         if (!response.ok) {
           throw new Error("Network response was not ok");
@@ -204,6 +212,10 @@ function Moderation() {
           },
         });
 
+        if (!response) {
+          throw new Error("API response is undefined");
+        }
+        
         if (!response.ok) {
           throw new Error("Network response was not ok");
         }


### PR DESCRIPTION
I have written unit tests for rendering the non-moderator view on moderation page and applying for becoming a moderator with a button click. It simulates a mock API call to see if button works. I have also added some undefined response checks to moderator page and I needed add a dependency to package.json files as a warning message suggested.