### PR TITLE
frontend/test/not-jury-page

### DIFF
--- a/prediction-polls/frontend/src/Pages/Moderation/NotJury.test.js
+++ b/prediction-polls/frontend/src/Pages/Moderation/NotJury.test.js
@@ -1,0 +1,98 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
+import { act } from 'react-dom/test-utils';
+import { MemoryRouter } from 'react-router-dom';
+import Moderation from './index.jsx';
+
+
+// Mock API response for moderator posts
+const mockModeratorPosts = [
+    {
+        "request_id": 0,
+        "request_type": "discrete",
+        "poll": {
+            "id": 0,
+            "question": "Which country will win Eurovision this year?",
+            "tags": [
+                "eurovision", "music"
+            ],
+            "creatorName": "string",
+            "creatorUsername": "string",
+            "creatorImage": "string",
+            "pollType": "string",
+            "closingDate": "string",
+            "rejectVotes": "string",
+            "isOpen": true,
+            "cont_poll_type": "string",
+            "comments": [
+                {
+                    "id": 0,
+                    "content": "string"
+                }
+            ],
+            "options": [
+                {
+                    "id": 0,
+                    "choice_text": "string",
+                    "poll_id": 0,
+                    "voter_count": 0
+                }
+            ]
+        }
+    }
+    ,
+    {
+        "request_id": 0,
+        "request_type": "report",
+        "poll": {
+            "id": 0,
+            "question": "When will the protests in France end?",
+            "tags": [
+                "France", "Politics"
+            ],
+            "creatorName": "string",
+            "creatorUsername": "string",
+            "creatorImage": "string",
+            "pollType": "string",
+            "closingDate": "string",
+            "rejectVotes": "string",
+            "isOpen": true,
+            "cont_poll_type": "string",
+            "comments": [
+                {
+                    "id": 0,
+                    "content": "string"
+                }
+            ],
+            "options": [
+                {
+                    "id": 0,
+                    "choice_text": "string",
+                    "poll_id": 0,
+                    "voter_count": 0
+                }
+            ]
+        }
+    }
+];
+  
+  // Mock API response for tags
+  const tags = [
+    { topic: 'topic1', isSelected: 0 },
+    { topic: 'topic2', isSelected: 1 },
+    { topic: 'topic3', isSelected: 1 },
+  ];
+
+
+describe('Moderation', () => {
+    test('renders the moderator view correctly', async () => { 
+        render(
+            <MemoryRouter>
+              <Moderation tags={tags} moderatorPosts={mockModeratorPosts} prevTags={tags} />
+            </MemoryRouter>
+        );
+
+        
+    });
+});


### PR DESCRIPTION
For the moderation-not-jury page: I have added mock data for moderation posts and tags. They simulate a normal response from backend. I tested if page renders with these mock data and it did. Other dynamic features of the page are tested manually since they change during execution like api requests.

![image](https://github.com/bounswe/bounswe2023group4/assets/110101098/146b3f2a-29c5-4df2-8170-17ac15b04969)
